### PR TITLE
`@0x/utils`: Restore revert error definitions :-(

### DIFF
--- a/utils/CHANGELOG.json
+++ b/utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.1.0",
+        "changes": [
+            {
+                "note": "Restore revert error definitions :-(",
+                "pr": 4
+            }
+        ]
+    },
+    {
         "version": "6.0.0",
         "changes": [
             {

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -27,3 +27,32 @@ export {
     AnyRevertError,
 } from './revert_error';
 export { fromTokenUnitAmount, toTokenUnitAmount } from './token_utils';
+
+export import BrokerRevertErrors = require('./revert_errors/broker/revert_errors');
+export import CoordinatorRevertErrors = require('./revert_errors/coordinator/revert_errors');
+export import ExchangeForwarderRevertErrors = require('./revert_errors/exchange-forwarder/revert_errors');
+export import LibMathRevertErrors = require('./revert_errors/exchange-libs/lib_math_revert_errors');
+export import ExchangeRevertErrors = require('./revert_errors/exchange/revert_errors');
+export import LibAssetDataTransferRevertErrors = require('./revert_errors/extensions/lib_asset_data_transfer_revert_errors');
+export import MixinWethUtilsRevertErrors = require('./revert_errors/extensions/mixin_weth_utils_revert_errors');
+export import FixedMathRevertErrors = require('./revert_errors/staking/fixed_math_revert_errors');
+export import StakingRevertErrors = require('./revert_errors/staking/staking_revert_errors');
+export import AuthorizableRevertErrors = require('./revert_errors/utils/authorizable_revert_errors');
+export import LibAddressArrayRevertErrors = require('./revert_errors/utils/lib_address_array_revert_errors');
+export import LibBytesRevertErrors = require('./revert_errors/utils/lib_bytes_revert_errors');
+export import OwnableRevertErrors = require('./revert_errors/utils/ownable_revert_errors');
+export import ReentrancyGuardRevertErrors = require('./revert_errors/utils/reentrancy_guard_revert_errors');
+export import SafeMathRevertErrors = require('./revert_errors/utils/safe_math_revert_errors');
+
+export const ZeroExRevertErrors = {
+    Common: require('./revert_errors/zero-ex/common_revert_errors'),
+    Proxy: require('./revert_errors/zero-ex/proxy_revert_errors'),
+    SimpleFunctionRegistry: require('./revert_errors/zero-ex/simple_function_registry_revert_errors'),
+    Ownable: require('./revert_errors/zero-ex/ownable_revert_errors'),
+    Spender: require('./revert_errors/zero-ex/spender_revert_errors'),
+    TransformERC20: require('./revert_errors/zero-ex/transform_erc20_revert_errors'),
+    Wallet: require('./revert_errors/zero-ex/wallet_revert_errors'),
+    MetaTransactions: require('./revert_errors/zero-ex/meta_transaction_revert_errors'),
+    SignatureValidator: require('./revert_errors/zero-ex/signature_validator_revert_errors'),
+    LiquidityProvider: require('./revert_errors/zero-ex/liquidity_provider_revert_errors'),
+};

--- a/utils/src/revert_error.ts
+++ b/utils/src/revert_error.ts
@@ -36,9 +36,10 @@ interface RevertErrorRegistryItem {
  * Register a RevertError type so that it can be decoded by
  * `decodeRevertError`.
  * @param revertClass A class that inherits from RevertError.
+ * @param force Allow overwriting registered types.
  */
-export function registerRevertErrorType(revertClass: RevertErrorType): void {
-    RevertError.registerType(revertClass);
+export function registerRevertErrorType(revertClass: RevertErrorType, force: boolean = false): void {
+    RevertError.registerType(revertClass, force);
 }
 
 /**
@@ -139,10 +140,11 @@ export abstract class RevertError extends Error {
      * Register a RevertError type so that it can be decoded by
      * `RevertError.decode`.
      * @param revertClass A class that inherits from RevertError.
+     * @param force Allow overwriting existing registrations.
      */
-    public static registerType(revertClass: RevertErrorType): void {
+    public static registerType(revertClass: RevertErrorType, force: boolean = false): void {
         const instance = new revertClass();
-        if (instance.selector in RevertError._typeRegistry) {
+        if (!force && instance.selector in RevertError._typeRegistry) {
             throw new Error(`RevertError type with signature "${instance.signature}" is already registered`);
         }
         if (_.isNil(instance.abi)) {

--- a/utils/src/revert_errors/broker/revert_errors.ts
+++ b/utils/src/revert_errors/broker/revert_errors.ts
@@ -1,0 +1,51 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export class InvalidFromAddressError extends RevertError {
+    constructor(from?: string) {
+        super('InvalidFromAddressError', 'InvalidFromAddressError(address from)', { from });
+    }
+}
+
+export class AmountsLengthMustEqualOneError extends RevertError {
+    constructor(amountsLength?: BigNumber | number | string) {
+        super('AmountsLengthMustEqualOneError', 'AmountsLengthMustEqualOneError(uint256 amountsLength)', {
+            amountsLength,
+        });
+    }
+}
+
+export class TooFewBrokerAssetsProvidedError extends RevertError {
+    constructor(numBrokeredAssets?: BigNumber | number | string) {
+        super('TooFewBrokerAssetsProvidedError', 'TooFewBrokerAssetsProvidedError(uint256 numBrokeredAssets)', {
+            numBrokeredAssets,
+        });
+    }
+}
+
+export class InvalidFunctionSelectorError extends RevertError {
+    constructor(selector?: string) {
+        super('InvalidFunctionSelectorError', 'InvalidFunctionSelectorError(bytes4 selector)', { selector });
+    }
+}
+
+export class OnlyERC1155ProxyError extends RevertError {
+    constructor(sender?: string) {
+        super('OnlyERC1155ProxyError', 'OnlyERC1155ProxyError(address sender)', { sender });
+    }
+}
+
+const types = [
+    InvalidFromAddressError,
+    AmountsLengthMustEqualOneError,
+    TooFewBrokerAssetsProvidedError,
+    InvalidFunctionSelectorError,
+    OnlyERC1155ProxyError,
+];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/coordinator/revert_errors.ts
+++ b/utils/src/revert_errors/coordinator/revert_errors.ts
@@ -1,0 +1,53 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export enum SignatureErrorCodes {
+    InvalidLength,
+    Unsupported,
+    Illegal,
+    Invalid,
+}
+
+export class SignatureError extends RevertError {
+    constructor(errorCode?: SignatureErrorCodes, hash?: string, signature?: string) {
+        super('SignatureError', 'SignatureError(uint8 errorCode, bytes32 hash, bytes signature)', {
+            errorCode,
+            hash,
+            signature,
+        });
+    }
+}
+
+export class InvalidOriginError extends RevertError {
+    constructor(expectedOrigin?: string) {
+        super('InvalidOriginError', 'InvalidOriginError(address expectedOrigin)', { expectedOrigin });
+    }
+}
+
+export class ApprovalExpiredError extends RevertError {
+    constructor(transactionHash?: string, approvalExpirationTime?: BigNumber | number | string) {
+        super('ApprovalExpiredError', 'ApprovalExpiredError(bytes32 transactionHash, uint256 approvalExpirationTime)', {
+            transactionHash,
+            approvalExpirationTime,
+        });
+    }
+}
+
+export class InvalidApprovalSignatureError extends RevertError {
+    constructor(transactionHash?: string, approverAddress?: string) {
+        super(
+            'InvalidApprovalSignatureError',
+            'InvalidApprovalSignatureError(bytes32 transactionHash, address approverAddress)',
+            { transactionHash, approverAddress },
+        );
+    }
+}
+
+const types = [SignatureError, InvalidOriginError, ApprovalExpiredError, InvalidApprovalSignatureError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/exchange-forwarder/revert_errors.ts
+++ b/utils/src/revert_errors/exchange-forwarder/revert_errors.ts
@@ -1,0 +1,71 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export class UnregisteredAssetProxyError extends RevertError {
+    constructor() {
+        super('UnregisteredAssetProxyError', 'UnregisteredAssetProxyError()', {});
+    }
+}
+
+export class CompleteBuyFailedError extends RevertError {
+    constructor(
+        expectedAssetBuyAmount?: BigNumber | number | string,
+        actualAssetBuyAmount?: BigNumber | number | string,
+    ) {
+        super(
+            'CompleteBuyFailedError',
+            'CompleteBuyFailedError(uint256 expectedAssetBuyAmount, uint256 actualAssetBuyAmount)',
+            { expectedAssetBuyAmount, actualAssetBuyAmount },
+        );
+    }
+}
+
+export class CompleteSellFailedError extends RevertError {
+    constructor(
+        expectedAssetSellAmount?: BigNumber | number | string,
+        actualAssetSellAmount?: BigNumber | number | string,
+    ) {
+        super(
+            'CompleteSellFailedError',
+            'CompleteSellFailedError(uint256 expectedAssetSellAmount, uint256 actualAssetSellAmount)',
+            { expectedAssetSellAmount, actualAssetSellAmount },
+        );
+    }
+}
+
+export class UnsupportedFeeError extends RevertError {
+    constructor(takerFeeAssetData?: string) {
+        super('UnsupportedFeeError', 'UnsupportedFeeError(bytes takerFeeAssetData)', { takerFeeAssetData });
+    }
+}
+
+export class OverspentWethError extends RevertError {
+    constructor(wethSpent?: BigNumber | number | string, msgValue?: BigNumber | number | string) {
+        super('OverspentWethError', 'OverspentWethError(uint256 wethSpent, uint256 msgValue)', {
+            wethSpent,
+            msgValue,
+        });
+    }
+}
+
+export class MsgValueCannotEqualZeroError extends RevertError {
+    constructor() {
+        super('MsgValueCannotEqualZeroError', 'MsgValueCannotEqualZeroError()', {});
+    }
+}
+
+const types = [
+    UnregisteredAssetProxyError,
+    CompleteBuyFailedError,
+    CompleteSellFailedError,
+    UnsupportedFeeError,
+    OverspentWethError,
+    MsgValueCannotEqualZeroError,
+];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/exchange-libs/lib_math_revert_errors.ts
+++ b/utils/src/revert_errors/exchange-libs/lib_math_revert_errors.ts
@@ -1,0 +1,33 @@
+import * as _ from 'lodash';
+
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export class DivisionByZeroError extends RevertError {
+    constructor() {
+        super('DivisionByZeroError', 'DivisionByZeroError()', {});
+    }
+}
+
+export class RoundingError extends RevertError {
+    constructor(
+        numerator?: BigNumber | number | string,
+        denominator?: BigNumber | number | string,
+        target?: BigNumber | number | string,
+    ) {
+        super('RoundingError', 'RoundingError(uint256 numerator, uint256 denominator, uint256 target)', {
+            numerator,
+            denominator,
+            target,
+        });
+    }
+}
+
+const types = [DivisionByZeroError, RoundingError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/exchange/revert_errors.ts
+++ b/utils/src/revert_errors/exchange/revert_errors.ts
@@ -1,0 +1,289 @@
+import { OrderStatus } from '@0x/types';
+import * as _ from 'lodash';
+
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export enum BatchMatchOrdersErrorCodes {
+    ZeroLeftOrders,
+    ZeroRightOrders,
+    InvalidLengthLeftSignatures,
+    InvalidLengthRightSignatures,
+}
+
+export enum ExchangeContextErrorCodes {
+    InvalidMaker,
+    InvalidTaker,
+    InvalidSender,
+}
+
+export enum FillErrorCode {
+    InvalidTakerAmount,
+    TakerOverpay,
+    Overfill,
+    InvalidFillPrice,
+}
+
+export enum SignatureErrorCode {
+    BadOrderSignature,
+    BadTransactionSignature,
+    InvalidLength,
+    Unsupported,
+    Illegal,
+    InappropriateSignatureType,
+    InvalidSigner,
+}
+
+export enum AssetProxyDispatchErrorCode {
+    InvalidAssetDataLength,
+    UnknownAssetProxy,
+}
+
+export enum TransactionErrorCode {
+    AlreadyExecuted,
+    Expired,
+}
+
+export enum IncompleteFillErrorCode {
+    IncompleteMarketBuyOrders,
+    IncompleteMarketSellOrders,
+    IncompleteFillOrder,
+}
+
+export class BatchMatchOrdersError extends RevertError {
+    constructor(error?: BatchMatchOrdersErrorCodes) {
+        super('BatchMatchOrdersError', 'BatchMatchOrdersError(uint8 error)', { error });
+    }
+}
+
+export class SignatureError extends RevertError {
+    constructor(error?: SignatureErrorCode, hash?: string, signer?: string, signature?: string) {
+        super('SignatureError', 'SignatureError(uint8 error, bytes32 hash, address signer, bytes signature)', {
+            error,
+            hash,
+            signer,
+            signature,
+        });
+    }
+}
+
+export class SignatureValidatorNotApprovedError extends RevertError {
+    constructor(signer?: string, validator?: string) {
+        super(
+            'SignatureValidatorNotApprovedError',
+            'SignatureValidatorNotApprovedError(address signer, address validator)',
+            {
+                signer,
+                validator,
+            },
+        );
+    }
+}
+
+export class SignatureWalletError extends RevertError {
+    constructor(hash?: string, wallet?: string, signature?: string, errorData?: string) {
+        super(
+            'SignatureWalletError',
+            'SignatureWalletError(bytes32 hash, address wallet, bytes signature, bytes errorData)',
+            {
+                hash,
+                wallet,
+                signature,
+                errorData,
+            },
+        );
+    }
+}
+
+export class EIP1271SignatureError extends RevertError {
+    constructor(verifyingContract?: string, data?: string, signature?: string, errorData?: string) {
+        super(
+            'EIP1271SignatureError',
+            'EIP1271SignatureError(address verifyingContract, bytes data, bytes signature, bytes errorData)',
+            {
+                verifyingContract,
+                data,
+                signature,
+                errorData,
+            },
+        );
+    }
+}
+
+export class OrderStatusError extends RevertError {
+    constructor(orderHash?: string, status?: OrderStatus) {
+        super('OrderStatusError', 'OrderStatusError(bytes32 orderHash, uint8 status)', { orderHash, status });
+    }
+}
+
+export class FillError extends RevertError {
+    constructor(error?: FillErrorCode, orderHash?: string) {
+        super('FillError', 'FillError(uint8 error, bytes32 orderHash)', { error, orderHash });
+    }
+}
+
+export class OrderEpochError extends RevertError {
+    constructor(maker?: string, sender?: string, currentEpoch?: BigNumber) {
+        super('OrderEpochError', 'OrderEpochError(address maker, address sender, uint256 currentEpoch)', {
+            maker,
+            sender,
+            currentEpoch,
+        });
+    }
+}
+
+export class AssetProxyExistsError extends RevertError {
+    constructor(assetProxyId?: string, assetProxy?: string) {
+        super('AssetProxyExistsError', 'AssetProxyExistsError(bytes4 assetProxyId, address assetProxy)', {
+            assetProxyId,
+            assetProxy,
+        });
+    }
+}
+
+export class AssetProxyDispatchError extends RevertError {
+    constructor(error?: AssetProxyDispatchErrorCode, orderHash?: string, assetData?: string) {
+        super('AssetProxyDispatchError', 'AssetProxyDispatchError(uint8 error, bytes32 orderHash, bytes assetData)', {
+            error,
+            orderHash,
+            assetData,
+        });
+    }
+}
+
+export class AssetProxyTransferError extends RevertError {
+    constructor(orderHash?: string, assetData?: string, errorData?: string) {
+        super(
+            'AssetProxyTransferError',
+            'AssetProxyTransferError(bytes32 orderHash, bytes assetData, bytes errorData)',
+            {
+                orderHash,
+                assetData,
+                errorData,
+            },
+        );
+    }
+}
+
+export class NegativeSpreadError extends RevertError {
+    constructor(leftOrderHash?: string, rightOrderHash?: string) {
+        super('NegativeSpreadError', 'NegativeSpreadError(bytes32 leftOrderHash, bytes32 rightOrderHash)', {
+            leftOrderHash,
+            rightOrderHash,
+        });
+    }
+}
+
+export class TransactionError extends RevertError {
+    constructor(error?: TransactionErrorCode, transactionHash?: string) {
+        super('TransactionError', 'TransactionError(uint8 error, bytes32 transactionHash)', { error, transactionHash });
+    }
+}
+
+export class TransactionExecutionError extends RevertError {
+    constructor(transactionHash?: string, errorData?: string) {
+        super('TransactionExecutionError', 'TransactionExecutionError(bytes32 transactionHash, bytes errorData)', {
+            transactionHash,
+            errorData,
+        });
+    }
+}
+
+export class TransactionGasPriceError extends RevertError {
+    constructor(transactionHash?: string, actualGasPrice?: BigNumber, requiredGasPrice?: BigNumber) {
+        super(
+            'TransactionGasPriceError',
+            'TransactionGasPriceError(bytes32 transactionHash, uint256 actualGasPrice, uint256 requiredGasPrice)',
+            {
+                transactionHash,
+                actualGasPrice,
+                requiredGasPrice,
+            },
+        );
+    }
+}
+
+export class TransactionInvalidContextError extends RevertError {
+    constructor(transactionHash?: string, currentContextAddress?: string) {
+        super(
+            'TransactionInvalidContextError',
+            'TransactionInvalidContextError(bytes32 transactionHash, address currentContextAddress)',
+            {
+                transactionHash,
+                currentContextAddress,
+            },
+        );
+    }
+}
+
+export class IncompleteFillError extends RevertError {
+    constructor(
+        error?: IncompleteFillErrorCode,
+        expectedAssetFillAmount?: BigNumber,
+        actualAssetFillAmount?: BigNumber,
+    ) {
+        super(
+            'IncompleteFillError',
+            'IncompleteFillError(uint8 error, uint256 expectedAssetFillAmount, uint256 actualAssetFillAmount)',
+            {
+                error,
+                expectedAssetFillAmount,
+                actualAssetFillAmount,
+            },
+        );
+    }
+}
+
+export class ExchangeInvalidContextError extends RevertError {
+    constructor(error?: ExchangeContextErrorCodes, orderHash?: string, contextAddress?: string) {
+        super(
+            'ExchangeInvalidContextError',
+            'ExchangeInvalidContextError(uint8 error, bytes32 orderHash, address contextAddress)',
+            { error, orderHash, contextAddress },
+        );
+    }
+}
+export class PayProtocolFeeError extends RevertError {
+    constructor(
+        orderHash?: string,
+        protocolFee?: BigNumber,
+        makerAddress?: string,
+        takerAddress?: string,
+        errorData?: string,
+    ) {
+        super(
+            'PayProtocolFeeError',
+            'PayProtocolFeeError(bytes32 orderHash, uint256 protocolFee, address makerAddress, address takerAddress, bytes errorData)',
+            { orderHash, protocolFee, makerAddress, takerAddress, errorData },
+        );
+    }
+}
+
+const types = [
+    AssetProxyExistsError,
+    AssetProxyDispatchError,
+    AssetProxyTransferError,
+    BatchMatchOrdersError,
+    EIP1271SignatureError,
+    ExchangeInvalidContextError,
+    FillError,
+    IncompleteFillError,
+    NegativeSpreadError,
+    OrderEpochError,
+    OrderStatusError,
+    PayProtocolFeeError,
+    SignatureError,
+    SignatureValidatorNotApprovedError,
+    SignatureWalletError,
+    TransactionError,
+    TransactionExecutionError,
+    TransactionGasPriceError,
+    TransactionInvalidContextError,
+];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/extensions/lib_asset_data_transfer_revert_errors.ts
+++ b/utils/src/revert_errors/extensions/lib_asset_data_transfer_revert_errors.ts
@@ -1,0 +1,25 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export class UnsupportedAssetProxyError extends RevertError {
+    constructor(proxyId?: string) {
+        super('UnsupportedAssetProxyError', 'UnsupportedAssetProxyError(bytes4 proxyId)', { proxyId });
+    }
+}
+
+export class Erc721AmountMustEqualOneError extends RevertError {
+    constructor(amount?: BigNumber | number | string) {
+        super('Erc721AmountMustEqualOneError', 'Erc721AmountMustEqualOneError(uint256 amount)', {
+            amount,
+        });
+    }
+}
+
+const types = [UnsupportedAssetProxyError, Erc721AmountMustEqualOneError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/extensions/mixin_weth_utils_revert_errors.ts
+++ b/utils/src/revert_errors/extensions/mixin_weth_utils_revert_errors.ts
@@ -1,0 +1,48 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export class UnregisteredAssetProxyError extends RevertError {
+    constructor() {
+        super('UnregisteredAssetProxyError', 'UnregisteredAssetProxyError()', {});
+    }
+}
+
+export class InsufficientEthForFeeError extends RevertError {
+    constructor(ethFeeRequired?: BigNumber | number | string, ethAvailable?: BigNumber | number | string) {
+        super(
+            'InsufficientEthForFeeError',
+            'InsufficientEthForFeeError(uint256 ethFeeRequired, uint256 ethAvailable)',
+            { ethFeeRequired, ethAvailable },
+        );
+    }
+}
+
+export class DefaultFunctionWethContractOnlyError extends RevertError {
+    constructor(senderAddress?: string) {
+        super('DefaultFunctionWethContractOnlyError', 'DefaultFunctionWethContractOnlyError(address senderAddress)', {
+            senderAddress,
+        });
+    }
+}
+
+export class EthFeeLengthMismatchError extends RevertError {
+    constructor(ethFeesLength?: BigNumber | number | string, feeRecipientsLength?: BigNumber | number | string) {
+        super(
+            'EthFeeLengthMismatchError',
+            'EthFeeLengthMismatchError(uint256 ethFeesLength, uint256 feeRecipientsLength)',
+            {
+                ethFeesLength,
+                feeRecipientsLength,
+            },
+        );
+    }
+}
+
+const types = [InsufficientEthForFeeError, DefaultFunctionWethContractOnlyError, EthFeeLengthMismatchError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/staking/fixed_math_revert_errors.ts
+++ b/utils/src/revert_errors/staking/fixed_math_revert_errors.ts
@@ -1,0 +1,51 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export enum ValueErrorCodes {
+    TooSmall,
+    TooLarge,
+}
+
+export enum BinOpErrorCodes {
+    AdditionOverflow,
+    MultiplicationOverflow,
+    DivisionByZero,
+    DivisionOverflow,
+}
+
+export class SignedValueError extends RevertError {
+    constructor(error?: ValueErrorCodes, n?: BigNumber | number | string) {
+        super('SignedValueError', 'SignedValueError(uint8 error, int256 n)', {
+            error,
+            n,
+        });
+    }
+}
+
+export class UnsignedValueError extends RevertError {
+    constructor(error?: ValueErrorCodes, n?: BigNumber | number | string) {
+        super('UnsignedValueError', 'UnsignedValueError(uint8 error, uint256 n)', {
+            error,
+            n,
+        });
+    }
+}
+
+export class BinOpError extends RevertError {
+    constructor(error?: BinOpErrorCodes, a?: BigNumber | number | string, b?: BigNumber | number | string) {
+        super('BinOpError', 'BinOpError(uint8 error, int256 a, int256 b)', {
+            error,
+            a,
+            b,
+        });
+    }
+}
+
+const types = [SignedValueError, UnsignedValueError, BinOpError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/staking/staking_revert_errors.ts
+++ b/utils/src/revert_errors/staking/staking_revert_errors.ts
@@ -1,0 +1,205 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export enum MakerPoolAssignmentErrorCodes {
+    MakerAddressAlreadyRegistered,
+    MakerAddressNotRegistered,
+    MakerAddressNotPendingAdd,
+    PoolIsFull,
+}
+
+export enum OperatorShareErrorCodes {
+    OperatorShareTooLarge,
+    CanOnlyDecreaseOperatorShare,
+}
+
+export enum InvalidParamValueErrorCodes {
+    InvalidCobbDouglasAlpha,
+    InvalidRewardDelegatedStakeWeight,
+    InvalidMaximumMakersInPool,
+    InvalidMinimumPoolStake,
+    InvalidEpochDuration,
+}
+
+export enum InitializationErrorCodes {
+    MixinSchedulerAlreadyInitialized,
+    MixinParamsAlreadyInitialized,
+}
+
+export enum ExchangeManagerErrorCodes {
+    ExchangeAlreadyRegistered,
+    ExchangeNotRegistered,
+}
+
+export class OnlyCallableByExchangeError extends RevertError {
+    constructor(senderAddress?: string) {
+        super('OnlyCallableByExchangeError', 'OnlyCallableByExchangeError(address senderAddress)', { senderAddress });
+    }
+}
+
+export class ExchangeManagerError extends RevertError {
+    constructor(errorCode?: ExchangeManagerErrorCodes, senderAddress?: string) {
+        super('ExchangeManagerError', 'ExchangeManagerError(uint8 errorCode, address senderAddress)', {
+            errorCode,
+            senderAddress,
+        });
+    }
+}
+
+export class InsufficientBalanceError extends RevertError {
+    constructor(amount?: BigNumber | number | string, balance?: BigNumber | number | string) {
+        super('InsufficientBalanceError', 'InsufficientBalanceError(uint256 amount, uint256 balance)', {
+            amount,
+            balance,
+        });
+    }
+}
+
+export class OnlyCallableByPoolOperatorError extends RevertError {
+    constructor(senderAddress?: string, poolId?: string) {
+        super(
+            'OnlyCallableByPoolOperatorError',
+            'OnlyCallableByPoolOperatorError(address senderAddress, bytes32 poolId)',
+            { senderAddress, poolId },
+        );
+    }
+}
+
+export class MakerPoolAssignmentError extends RevertError {
+    constructor(error?: MakerPoolAssignmentErrorCodes, makerAddress?: string, poolId?: string) {
+        super(
+            'MakerPoolAssignmentError',
+            'MakerPoolAssignmentError(uint8 error, address makerAddress, bytes32 poolId)',
+            {
+                error,
+                makerAddress,
+                poolId,
+            },
+        );
+    }
+}
+
+export class BlockTimestampTooLowError extends RevertError {
+    constructor(epochEndTime?: BigNumber | number | string, currentBlockTimestamp?: BigNumber | number | string) {
+        super(
+            'BlockTimestampTooLowError',
+            'BlockTimestampTooLowError(uint256 epochEndTime, uint256 currentBlockTimestamp)',
+            { epochEndTime, currentBlockTimestamp },
+        );
+    }
+}
+
+export class OnlyCallableByStakingContractError extends RevertError {
+    constructor(senderAddress?: string) {
+        super('OnlyCallableByStakingContractError', 'OnlyCallableByStakingContractError(address senderAddress)', {
+            senderAddress,
+        });
+    }
+}
+
+export class OnlyCallableIfInCatastrophicFailureError extends RevertError {
+    constructor() {
+        super('OnlyCallableIfInCatastrophicFailureError', 'OnlyCallableIfInCatastrophicFailureError()', {});
+    }
+}
+
+export class OnlyCallableIfNotInCatastrophicFailureError extends RevertError {
+    constructor() {
+        super('OnlyCallableIfNotInCatastrophicFailureError', 'OnlyCallableIfNotInCatastrophicFailureError()', {});
+    }
+}
+
+export class OperatorShareError extends RevertError {
+    constructor(error?: OperatorShareErrorCodes, poolId?: string, operatorShare?: BigNumber | number | string) {
+        super('OperatorShareError', 'OperatorShareError(uint8 error, bytes32 poolId, uint32 operatorShare)', {
+            error,
+            poolId,
+            operatorShare,
+        });
+    }
+}
+
+export class PoolExistenceError extends RevertError {
+    constructor(poolId?: string, alreadyExists?: boolean) {
+        super('PoolExistenceError', 'PoolExistenceError(bytes32 poolId, bool alreadyExists)', {
+            poolId,
+            alreadyExists,
+        });
+    }
+}
+
+export class InvalidParamValueError extends RevertError {
+    constructor(error?: InvalidParamValueErrorCodes) {
+        super('InvalidParamValueError', 'InvalidParamValueError(uint8 error)', {
+            error,
+        });
+    }
+}
+
+export class InvalidProtocolFeePaymentError extends RevertError {
+    constructor(
+        expectedProtocolFeePaid?: BigNumber | number | string,
+        actualProtocolFeePaid?: BigNumber | number | string,
+    ) {
+        super(
+            'InvalidProtocolFeePaymentError',
+            'InvalidProtocolFeePaymentError(uint256 expectedProtocolFeePaid, uint256 actualProtocolFeePaid)',
+            { expectedProtocolFeePaid, actualProtocolFeePaid },
+        );
+    }
+}
+
+export class InitializationError extends RevertError {
+    constructor(error?: InitializationErrorCodes) {
+        super('InitializationError', 'InitializationError(uint8 error)', { error });
+    }
+}
+
+export class ProxyDestinationCannotBeNilError extends RevertError {
+    constructor() {
+        super('ProxyDestinationCannotBeNilError', 'ProxyDestinationCannotBeNilError()', {});
+    }
+}
+
+export class PreviousEpochNotFinalizedError extends RevertError {
+    constructor(closingEpoch?: BigNumber | number | string, unfinalizedPoolsRemaining?: BigNumber | number | string) {
+        super(
+            'PreviousEpochNotFinalizedError',
+            'PreviousEpochNotFinalizedError(uint256 closingEpoch, uint256 unfinalizedPoolsRemaining)',
+            { closingEpoch, unfinalizedPoolsRemaining },
+        );
+    }
+}
+
+export class PoolNotFinalizedError extends RevertError {
+    constructor(poolId: string, epoch: BigNumber | number | string) {
+        super('PoolNotFinalizedError', 'PoolNotFinalizedError(bytes32 poolId, uint256 epoch)', { poolId, epoch });
+    }
+}
+
+const types = [
+    BlockTimestampTooLowError,
+    ExchangeManagerError,
+    InitializationError,
+    InsufficientBalanceError,
+    InvalidProtocolFeePaymentError,
+    InvalidParamValueError,
+    MakerPoolAssignmentError,
+    OnlyCallableByExchangeError,
+    OnlyCallableByPoolOperatorError,
+    OnlyCallableByStakingContractError,
+    OnlyCallableIfInCatastrophicFailureError,
+    OnlyCallableIfNotInCatastrophicFailureError,
+    OperatorShareError,
+    PoolExistenceError,
+    PreviousEpochNotFinalizedError,
+    ProxyDestinationCannotBeNilError,
+    PoolNotFinalizedError,
+];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/utils/authorizable_revert_errors.ts
+++ b/utils/src/revert_errors/utils/authorizable_revert_errors.ts
@@ -1,0 +1,56 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+export class AuthorizedAddressMismatchError extends RevertError {
+    constructor(authorized?: string, target?: string) {
+        super('AuthorizedAddressMismatchError', 'AuthorizedAddressMismatchError(address authorized, address target)', {
+            authorized,
+            target,
+        });
+    }
+}
+
+export class IndexOutOfBoundsError extends RevertError {
+    constructor(index?: BigNumber, len?: BigNumber) {
+        super('IndexOutOfBoundsError', 'IndexOutOfBoundsError(uint256 index, uint256 len)', { index, len });
+    }
+}
+
+export class SenderNotAuthorizedError extends RevertError {
+    constructor(sender?: string) {
+        super('SenderNotAuthorizedError', 'SenderNotAuthorizedError(address sender)', { sender });
+    }
+}
+
+export class TargetAlreadyAuthorizedError extends RevertError {
+    constructor(target?: string) {
+        super('TargetAlreadyAuthorizedError', 'TargetAlreadyAuthorizedError(address target)', { target });
+    }
+}
+
+export class TargetNotAuthorizedError extends RevertError {
+    constructor(target?: string) {
+        super('TargetNotAuthorizedError', 'TargetNotAuthorizedError(address target)', { target });
+    }
+}
+
+export class ZeroCantBeAuthorizedError extends RevertError {
+    constructor() {
+        super('ZeroCantBeAuthorizedError', 'ZeroCantBeAuthorizedError()', {});
+    }
+}
+
+const types = [
+    AuthorizedAddressMismatchError,
+    IndexOutOfBoundsError,
+    SenderNotAuthorizedError,
+    TargetAlreadyAuthorizedError,
+    TargetNotAuthorizedError,
+    ZeroCantBeAuthorizedError,
+];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/utils/lib_address_array_revert_errors.ts
+++ b/utils/src/revert_errors/utils/lib_address_array_revert_errors.ts
@@ -1,0 +1,14 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+export class MismanagedMemoryError extends RevertError {
+    constructor(freeMemPtr?: BigNumber, addressArrayEndPtr?: BigNumber) {
+        super('MismanagedMemoryError', 'MismanagedMemoryError(uint256 freeMemPtr, uint256 addressArrayEndPtr)', {
+            freeMemPtr,
+            addressArrayEndPtr,
+        });
+    }
+}
+
+// Register the MismanagedMemoryError type
+RevertError.registerType(MismanagedMemoryError);

--- a/utils/src/revert_errors/utils/lib_bytes_revert_errors.ts
+++ b/utils/src/revert_errors/utils/lib_bytes_revert_errors.ts
@@ -1,0 +1,26 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+export enum InvalidByteOperationErrorCodes {
+    FromLessThanOrEqualsToRequired,
+    ToLessThanOrEqualsLengthRequired,
+    LengthGreaterThanZeroRequired,
+    LengthGreaterThanOrEqualsFourRequired,
+    LengthGreaterThanOrEqualsTwentyRequired,
+    LengthGreaterThanOrEqualsThirtyTwoRequired,
+    LengthGreaterThanOrEqualsNestedBytesLengthRequired,
+    DestinationLengthGreaterThanOrEqualSourceLengthRequired,
+}
+
+export class InvalidByteOperationError extends RevertError {
+    constructor(error?: InvalidByteOperationErrorCodes, offset?: BigNumber, required?: BigNumber) {
+        super('InvalidByteOperationError', 'InvalidByteOperationError(uint8 error, uint256 offset, uint256 required)', {
+            error,
+            offset,
+            required,
+        });
+    }
+}
+
+// Register the InvalidByteOperationError type
+RevertError.registerType(InvalidByteOperationError);

--- a/utils/src/revert_errors/utils/ownable_revert_errors.ts
+++ b/utils/src/revert_errors/utils/ownable_revert_errors.ts
@@ -1,0 +1,24 @@
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+export class OnlyOwnerError extends RevertError {
+    constructor(sender?: string, owner?: string) {
+        super('OnlyOwnerError', 'OnlyOwnerError(address sender, address owner)', {
+            sender,
+            owner,
+        });
+    }
+}
+
+export class TransferOwnerToZeroError extends RevertError {
+    constructor() {
+        super('TransferOwnerToZeroError', 'TransferOwnerToZeroError()', {});
+    }
+}
+
+const types = [OnlyOwnerError, TransferOwnerToZeroError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/utils/reentrancy_guard_revert_errors.ts
+++ b/utils/src/revert_errors/utils/reentrancy_guard_revert_errors.ts
@@ -1,0 +1,10 @@
+import { RevertError } from '../../revert_error';
+
+export class IllegalReentrancyError extends RevertError {
+    constructor() {
+        super('IllegalReentrancyError', 'IllegalReentrancyError()', {});
+    }
+}
+
+// Register the IllegalReentrancyError type
+RevertError.registerType(IllegalReentrancyError);

--- a/utils/src/revert_errors/utils/safe_math_revert_errors.ts
+++ b/utils/src/revert_errors/utils/safe_math_revert_errors.ts
@@ -1,0 +1,63 @@
+import { BigNumber } from '../../configured_bignumber';
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export enum BinOpErrorCodes {
+    AdditionOverflow,
+    MultiplicationOverflow,
+    SubtractionUnderflow,
+    DivisionByZero,
+}
+
+export enum DowncastErrorCodes {
+    ValueTooLargeToDowncastToUint32,
+    ValueTooLargeToDowncastToUint64,
+    ValueTooLargeToDowncastToUint96,
+}
+
+export class Uint256BinOpError extends RevertError {
+    constructor(error?: BinOpErrorCodes, a?: BigNumber, b?: BigNumber) {
+        super('Uint256BinOpError', 'Uint256BinOpError(uint8 error, uint256 a, uint256 b)', {
+            error,
+            a,
+            b,
+        });
+    }
+}
+
+export class Uint96BinOpError extends RevertError {
+    constructor(error?: BinOpErrorCodes, a?: BigNumber, b?: BigNumber) {
+        super('Uint96BinOpError', 'Uint96BinOpError(uint8 error, uint96 a, uint96 b)', {
+            error,
+            a,
+            b,
+        });
+    }
+}
+
+export class Uint64BinOpError extends RevertError {
+    constructor(error?: BinOpErrorCodes, a?: BigNumber, b?: BigNumber) {
+        super('Uint64BinOpError', 'Uint64BinOpError(uint8 error, uint64 a, uint64 b)', {
+            error,
+            a,
+            b,
+        });
+    }
+}
+
+export class Uint256DowncastError extends RevertError {
+    constructor(error?: DowncastErrorCodes, a?: BigNumber) {
+        super('Uint256DowncastError', 'Uint256DowncastError(uint8 error, uint256 a)', {
+            error,
+            a,
+        });
+    }
+}
+
+const types = [Uint256BinOpError, Uint96BinOpError, Uint64BinOpError, Uint256DowncastError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/common_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/common_revert_errors.ts
@@ -1,0 +1,27 @@
+import { RevertError } from '../../revert_error';
+import { Numberish } from '../../types';
+
+// tslint:disable:max-classes-per-file
+export class OnlyCallableBySelfError extends RevertError {
+    constructor(sender?: string) {
+        super('OnlyCallableBySelfError', 'OnlyCallableBySelfError(address sender)', {
+            sender,
+        });
+    }
+}
+
+export class IllegalReentrancyError extends RevertError {
+    constructor(selector?: string, reentrancyFlags?: Numberish) {
+        super('IllegalReentrancyError', 'IllegalReentrancyError(bytes4 selector, uint256 reentrancyFlags)', {
+            selector,
+            reentrancyFlags,
+        });
+    }
+}
+
+const types = [OnlyCallableBySelfError, IllegalReentrancyError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/liquidity_provider_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/liquidity_provider_revert_errors.ts
@@ -1,0 +1,47 @@
+import { RevertError } from '../../revert_error';
+import { Numberish } from '../../types';
+
+// tslint:disable:max-classes-per-file
+export class LiquidityProviderIncompleteSellError extends RevertError {
+    constructor(
+        providerAddress?: string,
+        makerToken?: string,
+        takerToken?: string,
+        sellAmount?: Numberish,
+        boughtAmount?: Numberish,
+        minBuyAmount?: Numberish,
+    ) {
+        super(
+            'LiquidityProviderIncompleteSellError',
+            'LiquidityProviderIncompleteSellError(address providerAddress, address makerToken, address takerToken, uint256 sellAmount, uint256 boughtAmount, uint256 minBuyAmount)',
+            {
+                providerAddress,
+                makerToken,
+                takerToken,
+                sellAmount,
+                boughtAmount,
+                minBuyAmount,
+            },
+        );
+    }
+}
+
+export class NoLiquidityProviderForMarketError extends RevertError {
+    constructor(xAsset?: string, yAsset?: string) {
+        super(
+            'NoLiquidityProviderForMarketError',
+            'NoLiquidityProviderForMarketError(address xAsset, address yAsset)',
+            {
+                xAsset,
+                yAsset,
+            },
+        );
+    }
+}
+
+const types = [LiquidityProviderIncompleteSellError, NoLiquidityProviderForMarketError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/meta_transaction_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/meta_transaction_revert_errors.ts
@@ -1,0 +1,144 @@
+import { RevertError } from '../../revert_error';
+import { Numberish } from '../../types';
+
+// tslint:disable:max-classes-per-file
+export class InvalidMetaTransactionsArrayLengthsError extends RevertError {
+    constructor(mtxCount?: Numberish, signatureCount?: Numberish) {
+        super(
+            'InvalidMetaTransactionsArrayLengthsError',
+            'InvalidMetaTransactionsArrayLengthsError(uint256 mtxCount, uint256 signatureCount)',
+            {
+                mtxCount,
+                signatureCount,
+            },
+        );
+    }
+}
+
+export class MetaTransactionAlreadyExecutedError extends RevertError {
+    constructor(mtxHash?: string, executedBlockNumber?: Numberish) {
+        super(
+            'MetaTransactionAlreadyExecutedError',
+            'MetaTransactionAlreadyExecutedError(bytes32 mtxHash, uint256 executedBlockNumber)',
+            {
+                mtxHash,
+                executedBlockNumber,
+            },
+        );
+    }
+}
+
+export class MetaTransactionUnsupportedFunctionError extends RevertError {
+    constructor(mtxHash?: string, selector?: string) {
+        super(
+            'MetaTransactionUnsupportedFunctionError',
+            'MetaTransactionUnsupportedFunctionError(bytes32 mtxHash, bytes4 selector)',
+            {
+                mtxHash,
+                selector,
+            },
+        );
+    }
+}
+
+export class MetaTransactionWrongSenderError extends RevertError {
+    constructor(mtxHash?: string, sender?: string, expectedSender?: string) {
+        super(
+            'MetaTransactionWrongSenderError',
+            'MetaTransactionWrongSenderError(bytes32 mtxHash, address sender, address expectedSender)',
+            {
+                mtxHash,
+                sender,
+                expectedSender,
+            },
+        );
+    }
+}
+
+export class MetaTransactionExpiredError extends RevertError {
+    constructor(mtxHash?: string, time?: Numberish, expirationTime?: Numberish) {
+        super(
+            'MetaTransactionExpiredError',
+            'MetaTransactionExpiredError(bytes32 mtxHash, uint256 time, uint256 expirationTime)',
+            {
+                mtxHash,
+                time,
+                expirationTime,
+            },
+        );
+    }
+}
+
+export class MetaTransactionGasPriceError extends RevertError {
+    constructor(mtxHash?: string, gasPrice?: Numberish, minGasPrice?: Numberish, maxGasPrice?: Numberish) {
+        super(
+            'MetaTransactionGasPriceError',
+            'MetaTransactionGasPriceError(bytes32 mtxHash, uint256 gasPrice, uint256 minGasPrice, uint256 maxGasPrice)',
+            {
+                mtxHash,
+                gasPrice,
+                minGasPrice,
+                maxGasPrice,
+            },
+        );
+    }
+}
+
+export class MetaTransactionInsufficientEthError extends RevertError {
+    constructor(mtxHash?: string, ethBalance?: Numberish, ethRequired?: Numberish) {
+        super(
+            'MetaTransactionInsufficientEthError',
+            'MetaTransactionInsufficientEthError(bytes32 mtxHash, uint256 ethBalance, uint256 ethRequired)',
+            {
+                mtxHash,
+                ethBalance,
+                ethRequired,
+            },
+        );
+    }
+}
+
+export class MetaTransactionInvalidSignatureError extends RevertError {
+    constructor(mtxHash?: string, signature?: string, errData?: string) {
+        super(
+            'MetaTransactionInvalidSignatureError',
+            'MetaTransactionInvalidSignatureError(bytes32 mtxHash, bytes signature, bytes errData)',
+            {
+                mtxHash,
+                signature,
+                errData,
+            },
+        );
+    }
+}
+
+export class MetaTransactionCallFailedError extends RevertError {
+    constructor(mtxHash?: string, callData?: string, returnData?: string) {
+        super(
+            'MetaTransactionCallFailedError',
+            'MetaTransactionCallFailedError(bytes32 mtxHash, bytes callData, bytes returnData)',
+            {
+                mtxHash,
+                callData,
+                returnData,
+            },
+        );
+    }
+}
+
+const types = [
+    InvalidMetaTransactionsArrayLengthsError,
+    MetaTransactionAlreadyExecutedError,
+    MetaTransactionUnsupportedFunctionError,
+    MetaTransactionWrongSenderError,
+    MetaTransactionExpiredError,
+    MetaTransactionGasPriceError,
+    MetaTransactionInsufficientEthError,
+    MetaTransactionInvalidSignatureError,
+    MetaTransactionCallFailedError,
+];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/ownable_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/ownable_revert_errors.ts
@@ -1,0 +1,35 @@
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export class MigrateCallFailedError extends RevertError {
+    constructor(target?: string, resultData?: string) {
+        super('MigrateCallFailedError', 'MigrateCallFailedError(address target, bytes resultData)', {
+            target,
+            resultData,
+        });
+    }
+}
+
+export class OnlyOwnerError extends RevertError {
+    constructor(sender?: string, owner?: string) {
+        super('OnlyOwnerError', 'OnlyOwnerError(address sender, bytes owner)', {
+            sender,
+            owner,
+        });
+    }
+}
+
+// This is identical to the one in utils.
+// export class TransferOwnerToZeroError extends RevertError {
+//     constructor() {
+//         super('TransferOwnerToZeroError', 'TransferOwnerToZeroError()', {});
+//     }
+// }
+
+const types = [MigrateCallFailedError, OnlyOwnerError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/proxy_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/proxy_revert_errors.ts
@@ -1,0 +1,44 @@
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+export class NotImplementedError extends RevertError {
+    constructor(selector?: string) {
+        super('NotImplementedError', 'NotImplementedError(bytes4 selector)', {
+            selector,
+        });
+    }
+}
+
+export class InvalidBootstrapCallerError extends RevertError {
+    constructor(caller?: string, expectedCaller?: string) {
+        super('InvalidBootstrapCallerError', 'InvalidBootstrapCallerError(address caller, address expectedCaller)', {
+            caller,
+            expectedCaller,
+        });
+    }
+}
+
+export class InvalidDieCallerError extends RevertError {
+    constructor(caller?: string, expectedCaller?: string) {
+        super('InvalidDieCallerError', 'InvalidDieCallerError(address caller, address expectedCaller)', {
+            caller,
+            expectedCaller,
+        });
+    }
+}
+
+export class BootstrapCallFailedError extends RevertError {
+    constructor(target?: string, resultData?: string) {
+        super('BootstrapCallFailedError', 'BootstrapCallFailedError(address target, bytes resultData)', {
+            target,
+            resultData,
+        });
+    }
+}
+
+const types = [BootstrapCallFailedError, InvalidBootstrapCallerError, InvalidDieCallerError, NotImplementedError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/signature_validator_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/signature_validator_revert_errors.ts
@@ -1,0 +1,33 @@
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+
+export enum SignatureValidationErrorCodes {
+    AlwaysInvalid = 0,
+    InvalidLength = 1,
+    Unsupported = 2,
+    Illegal = 3,
+    WrongSigner = 4,
+}
+
+export class SignatureValidationError extends RevertError {
+    constructor(code?: SignatureValidationErrorCodes, hash?: string, signerAddress?: string, signature?: string) {
+        super(
+            'SignatureValidationError',
+            'SignatureValidationError(uint8 code, bytes32 hash, address signerAddress, bytes signature)',
+            {
+                code,
+                hash,
+                signerAddress,
+                signature,
+            },
+        );
+    }
+}
+
+const types = [SignatureValidationError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/simple_function_registry_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/simple_function_registry_revert_errors.ts
@@ -1,0 +1,18 @@
+import { RevertError } from '../../revert_error';
+
+// tslint:disable:max-classes-per-file
+export class NotInRollbackHistoryError extends RevertError {
+    constructor(selector?: string, targetImpl?: string) {
+        super('NotInRollbackHistoryError', 'NotInRollbackHistoryError(bytes4 selector, address targetImpl)', {
+            selector,
+            targetImpl,
+        });
+    }
+}
+
+const types = [NotInRollbackHistoryError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/spender_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/spender_revert_errors.ts
@@ -1,0 +1,26 @@
+import { RevertError } from '../../revert_error';
+import { Numberish } from '../../types';
+
+// tslint:disable:max-classes-per-file
+export class SpenderERC20TransferFromFailedError extends RevertError {
+    constructor(token?: string, owner?: string, to?: string, amount?: Numberish, errorData?: string) {
+        super(
+            'SpenderERC20TransferFromFailedError',
+            'SpenderERC20TransferFromFailedError(address token, address owner, address to, uint256 amount, bytes errorData)',
+            {
+                token,
+                owner,
+                to,
+                amount,
+                errorData,
+            },
+        );
+    }
+}
+
+const types = [SpenderERC20TransferFromFailedError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/transform_erc20_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/transform_erc20_revert_errors.ts
@@ -1,0 +1,199 @@
+import { RevertError } from '../../revert_error';
+import { Numberish } from '../../types';
+
+// tslint:disable:max-classes-per-file
+export class InsufficientEthAttachedError extends RevertError {
+    constructor(ethAttached?: Numberish, ethNeeded?: Numberish) {
+        super('InsufficientEthAttachedError', 'InsufficientEthAttachedError(uint256 ethAttached, uint256 ethNeeded)', {
+            ethAttached,
+            ethNeeded,
+        });
+    }
+}
+
+export class IncompleteTransformERC20Error extends RevertError {
+    constructor(outputToken?: string, outputTokenAmount?: Numberish, minOutputTokenAmount?: Numberish) {
+        super(
+            'IncompleteTransformERC20Error',
+            'IncompleteTransformERC20Error(address outputToken, uint256 outputTokenAmount, uint256 minOutputTokenAmount)',
+            {
+                outputToken,
+                outputTokenAmount,
+                minOutputTokenAmount,
+            },
+        );
+    }
+}
+
+export class NegativeTransformERC20OutputError extends RevertError {
+    constructor(outputToken?: string, outputTokenLostAmount?: Numberish) {
+        super(
+            'NegativeTransformERC20OutputError',
+            'NegativeTransformERC20OutputError(address outputToken, uint256 outputTokenLostAmount)',
+            {
+                outputToken,
+                outputTokenLostAmount,
+            },
+        );
+    }
+}
+
+export class TransformerFailedError extends RevertError {
+    constructor(transformer?: string, transformerData?: string, resultData?: string) {
+        super(
+            'TransformerFailedError',
+            'TransformerFailedError(address transformer, bytes transformerData, bytes resultData)',
+            {
+                transformer,
+                transformerData,
+                resultData,
+            },
+        );
+    }
+}
+
+export class OnlyCallableByDeployerError extends RevertError {
+    constructor(caller?: string, deployer?: string) {
+        super('OnlyCallableByDeployerError', 'OnlyCallableByDeployerError(address caller, address deployer)', {
+            caller,
+            deployer,
+        });
+    }
+}
+
+export class InvalidExecutionContextError extends RevertError {
+    constructor(actualContext?: string, expectedContext?: string) {
+        super(
+            'InvalidExecutionContextError',
+            'InvalidExecutionContextError(address actualContext, address expectedContext)',
+            {
+                actualContext,
+                expectedContext,
+            },
+        );
+    }
+}
+
+export enum InvalidTransformDataErrorCode {
+    InvalidTokens,
+    InvalidArrayLength,
+}
+
+export class InvalidTransformDataError extends RevertError {
+    constructor(errorCode?: InvalidTransformDataErrorCode, transformData?: string) {
+        super('InvalidTransformDataError', 'InvalidTransformDataError(uint8 errorCode, bytes transformData)', {
+            errorCode,
+            transformData,
+        });
+    }
+}
+
+export class IncompleteFillSellQuoteError extends RevertError {
+    constructor(sellToken?: string, soldAmount?: Numberish, sellAmount?: Numberish) {
+        super(
+            'IncompleteFillSellQuoteError',
+            'IncompleteFillSellQuoteError(address sellToken, uint256 soldAmount, uint256 sellAmount)',
+            {
+                sellToken,
+                soldAmount,
+                sellAmount,
+            },
+        );
+    }
+}
+
+export class IncompleteFillBuyQuoteError extends RevertError {
+    constructor(buyToken?: string, boughtAmount?: Numberish, buyAmount?: Numberish) {
+        super(
+            'IncompleteFillBuyQuoteError',
+            'IncompleteFillBuyQuoteError(address buyToken, uint256 boughtAmount, uint256 buyAmount)',
+            {
+                buyToken,
+                boughtAmount,
+                buyAmount,
+            },
+        );
+    }
+}
+
+export class InsufficientTakerTokenError extends RevertError {
+    constructor(tokenBalance?: Numberish, tokensNeeded?: Numberish) {
+        super(
+            'InsufficientTakerTokenError',
+            'InsufficientTakerTokenError(uint256 tokenBalance, uint256 tokensNeeded)',
+            {
+                tokenBalance,
+                tokensNeeded,
+            },
+        );
+    }
+}
+
+export class InsufficientProtocolFeeError extends RevertError {
+    constructor(ethBalance?: Numberish, ethNeeded?: Numberish) {
+        super('InsufficientProtocolFeeError', 'InsufficientProtocolFeeError(uint256 ethBalance, uint256 ethNeeded)', {
+            ethBalance,
+            ethNeeded,
+        });
+    }
+}
+
+export class InvalidERC20AssetDataError extends RevertError {
+    constructor(assetData?: string) {
+        super('InvalidERC20AssetDataError', 'InvalidERC20AssetDataError(bytes assetData)', {
+            assetData,
+        });
+    }
+}
+
+export class WrongNumberOfTokensReceivedError extends RevertError {
+    constructor(actual?: Numberish, expected?: Numberish) {
+        super(
+            'WrongNumberOfTokensReceivedError',
+            'WrongNumberOfTokensReceivedError(uint256 actual, uint256 expected)',
+            {
+                actual,
+                expected,
+            },
+        );
+    }
+}
+
+export class InvalidTokenReceivedError extends RevertError {
+    constructor(token?: string) {
+        super('InvalidTokenReceivedError', 'InvalidTokenReceivedError(address token)', {
+            token,
+        });
+    }
+}
+
+export class InvalidTakerFeeTokenError extends RevertError {
+    constructor(token?: string) {
+        super('InvalidTakerFeeTokenError', 'InvalidTakerFeeTokenError(address token)', {
+            token,
+        });
+    }
+}
+
+const types = [
+    InsufficientEthAttachedError,
+    IncompleteTransformERC20Error,
+    NegativeTransformERC20OutputError,
+    TransformerFailedError,
+    IncompleteFillSellQuoteError,
+    IncompleteFillBuyQuoteError,
+    InsufficientTakerTokenError,
+    InsufficientProtocolFeeError,
+    InvalidERC20AssetDataError,
+    WrongNumberOfTokensReceivedError,
+    InvalidTokenReceivedError,
+    InvalidTransformDataError,
+    InvalidTakerFeeTokenError,
+    OnlyCallableByDeployerError,
+    InvalidExecutionContextError,
+];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}

--- a/utils/src/revert_errors/zero-ex/wallet_revert_errors.ts
+++ b/utils/src/revert_errors/zero-ex/wallet_revert_errors.ts
@@ -1,0 +1,41 @@
+import { RevertError } from '../../revert_error';
+import { Numberish } from '../../types';
+
+// tslint:disable:max-classes-per-file
+export class WalletExecuteCallFailedError extends RevertError {
+    constructor(wallet?: string, callTarget?: string, callData?: string, callValue?: Numberish, errorData?: string) {
+        super(
+            'WalletExecuteCallFailedError',
+            'WalletExecuteCallFailedError(address wallet, address callTarget, bytes callData, uint256 callValue, bytes errorData)',
+            {
+                wallet,
+                callTarget,
+                callData,
+                callValue,
+                errorData,
+            },
+        );
+    }
+}
+
+export class WalletExecuteDelegateCallFailedError extends RevertError {
+    constructor(wallet?: string, callTarget?: string, callData?: string, errorData?: string) {
+        super(
+            'WalletExecuteDelegateCallFailedError',
+            'WalletExecuteDelegateCallFailedError(address wallet, address callTarget, bytes callData, bytes errorData)',
+            {
+                wallet,
+                callTarget,
+                callData,
+                errorData,
+            },
+        );
+    }
+}
+
+const types = [WalletExecuteCallFailedError, WalletExecuteDelegateCallFailedError];
+
+// Register the types we've defined.
+for (const type of types) {
+    RevertError.registerType(type);
+}


### PR DESCRIPTION
## Description

OK, turns out #3 requires an absurd amount of work in the `protocol` repo so this reintroduces the revert error definitions, but the ability to override registration so the defs can be duplicated in `protocol-utils`.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
