### PR TITLE
Only persist the relevant contract sources to standard input JSON

### DIFF
--- a/sol-compiler/CHANGELOG.json
+++ b/sol-compiler/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.3.1",
+        "changes": [
+            {
+                "note": "Only write relevant sources to Standard Input JSON artifacts",
+                "pr": "TBD"
+            }
+        ]
+    },
+    {
         "version": "4.3.0",
         "changes": [
             {

--- a/sol-compiler/CHANGELOG.json
+++ b/sol-compiler/CHANGELOG.json
@@ -4,7 +4,7 @@
         "changes": [
             {
                 "note": "Only write relevant sources to Standard Input JSON artifacts",
-                "pr": "TBD"
+                "pr": 9
             }
         ]
     },

--- a/sol-compiler/src/compiler.ts
+++ b/sol-compiler/src/compiler.ts
@@ -436,6 +436,7 @@ export class Compiler {
                 `${this._artifactsDir}/${contractName}.input.json`,
                 utils.stringifyWithFormatting({
                     ...compilerInput,
+                    sources: _.mapValues(usedSources, ({ id }) => ({ id })),
                     // Insert solcVersion into input.
                     settings: {
                         ...compilerInput.settings,


### PR DESCRIPTION
## Description

Prior to this fix PR, all of the sources encountered during the invocation of `@0x/sol-compiler` would be written to the Standard Input JSON artifacts that are created when the `shouldSaveStandardInput` compiler option is set. This causes all of the contracts in a build to be included when these artifacts are submitted to Etherscan and seems somewhat unnecessary.

This PR simply addresses this issue by adopting the strategy that is used to write sources of 0x contract artifacts.

## Testing instructions

Build a contracts directory with `shouldSaveStandardInput` set to `true`. Look at one of the Standard Input artifacts for a contract that should not have sources for all of the compiled Solidity files and ensure that it only has the relevant sources.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
