### PR TITLE
`shouldCompileIndependently` sol-compiler option

### DIFF
--- a/ethereum-types/CHANGELOG.json
+++ b/ethereum-types/CHANGELOG.json
@@ -4,7 +4,7 @@
         "changes": [
             {
                 "note": "Add `shouldCompileIndependently` to `CompilerOptions`",
-                "pr": "TODO"
+                "pr": 12
             }
         ]
     },

--- a/ethereum-types/CHANGELOG.json
+++ b/ethereum-types/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "3.4.0",
+        "changes": [
+            {
+                "note": "Add `shouldCompileIndependently` to `CompilerOptions`",
+                "pr": "TODO"
+            }
+        ]
+    },
+    {
         "version": "3.3.3",
         "changes": [
             {

--- a/ethereum-types/src/index.ts
+++ b/ethereum-types/src/index.ts
@@ -753,6 +753,7 @@ export interface CompilerOptions {
     isOfflineMode?: boolean;
     solcVersion?: string;
     shouldSaveStandardInput?: boolean;
+    shouldCompileIndependently?: boolean;
 }
 
 export interface BlockRange {

--- a/sol-compiler/CHANGELOG.json
+++ b/sol-compiler/CHANGELOG.json
@@ -4,7 +4,7 @@
         "changes": [
             {
                 "note": "Support `shouldCompileIndependently` compiler option for non-batched compilation.",
-                "pr": "TODO"
+                "pr": 12
             }
         ]
     },

--- a/sol-compiler/CHANGELOG.json
+++ b/sol-compiler/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "4.4.0",
+        "changes": [
+            {
+                "note": "Support `shouldCompileIndependently` compiler option for non-batched compilation.",
+                "pr": "TODO"
+            }
+        ]
+    },
+    {
         "timestamp": 1606855909,
         "version": "4.3.3",
         "changes": [

--- a/sol-compiler/src/compiler.ts
+++ b/sol-compiler/src/compiler.ts
@@ -174,7 +174,7 @@ export class Compiler {
      */
     public async getCompilerOutputsAsync(): Promise<StandardOutput[]> {
         const promisedOutputs = await this._compileContractsAsync(this.getContractNamesToCompile(), {
-            shouldPersist: true,
+            shouldPersist: false,
             shouldCompileIndependently: false,
         });
         // Batching is disabled so only the first unit for each version is used.

--- a/sol-compiler/src/schemas/compiler_options_schema.ts
+++ b/sol-compiler/src/schemas/compiler_options_schema.ts
@@ -22,6 +22,7 @@ export const compilerOptionsSchema = {
         useDockerisedSolc: { type: 'boolean' },
         isOfflineMode: { type: 'boolean' },
         shouldSaveStandardInput: { type: 'boolean' },
+        shouldCompileIndependently: { type: 'boolean' },
     },
     type: 'object',
     required: [],

--- a/sol-compiler/src/utils/constants.ts
+++ b/sol-compiler/src/utils/constants.ts
@@ -5,6 +5,8 @@ export const constants = {
     BASE_COMPILER_URL: 'https://solc-bin.ethereum.org/bin/',
     LATEST_ARTIFACT_VERSION: '2.0.0',
     SOLC_BIN_DIR: path.join(__dirname, '..', '..', '..', 'solc_bin'),
+    SOLCJS_RELEASES_PATH: path.join(__dirname, '..', '..', '..', 'solc_bin', 'solcjs_releases.json'),
+    SOLCJS_RELEASES_CACHE_EXPIRY: 60e3,
     SOLC_BIN_PATHS: {
         '0.5.12': 'soljson-v0.5.12+commit.7709ece9.js',
         '0.5.11': 'soljson-v0.5.11+commit.c082d0b4.js',

--- a/sol-compiler/test/compiler_test.ts
+++ b/sol-compiler/test/compiler_test.ts
@@ -53,6 +53,29 @@ describe('#Compiler', function(): void {
         const exchangeBinaryWithoutMetadata = hexUtils.slice(exchange_binary, 0, -METADATA_SIZE);
         expect(unlinkedBinaryWithoutMetadata).to.equal(exchangeBinaryWithoutMetadata);
     });
+    it('can create an Exchange artifact with independent compilation', async () => {
+        compilerOpts.contracts = ['Exchange'];
+
+        const exchangeArtifactPath = `${artifactsDir}/Exchange.json`;
+        if (fsWrapper.doesPathExistSync(exchangeArtifactPath)) {
+            await fsWrapper.removeFileAsync(exchangeArtifactPath);
+        }
+
+        await new Compiler({ ...compilerOpts, shouldCompileIndependently: true }).compileAsync();
+
+        const opts = {
+            encoding: 'utf8',
+        };
+        const exchangeArtifactString = await fsWrapper.readFileAsync(exchangeArtifactPath, opts);
+        const exchangeArtifact: ContractArtifact = JSON.parse(exchangeArtifactString);
+        const unlinkedBinaryWithoutMetadata = hexUtils.slice(
+            exchangeArtifact.compilerOutput.evm.bytecode.object,
+            0,
+            -METADATA_SIZE,
+        );
+        const exchangeBinaryWithoutMetadata = hexUtils.slice(exchange_binary, 0, -METADATA_SIZE);
+        expect(unlinkedBinaryWithoutMetadata).to.equal(exchangeBinaryWithoutMetadata);
+    });
     it("should throw when Whatever.sol doesn't contain a Whatever contract", async () => {
         const contract = 'BadContractName';
 


### PR DESCRIPTION
## Description

We're having an issue with contracts not being verifiable on etherscan because the standard json input file we provide is too big for some packages (`zero-ex`). This is because the current behavior of `sol-compiler` is to batch all compatible contract files into a single standard input compilation unit. This is probably faster than individual compilation but also leads to massive input files that often contain sources that are not used by the target contract being compiled.

This PR introduces a new option/behavior to `sol-compiler` called `shouldCompileIndependently`, which will give each target contract its own compilation unit and standard input file, only including the relevant sources therein. This should allow us to verify on etherscan again as well as make verified contracts more readable as they will not contain useless contracts, like test contracts.

I also added pre-fetching and caching of solcJS binaries and caching of the solcJS releases manifests to get around out-of-memory issues. Might also speed up whole-project compilation times.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
