### PR TITLE
Add support for `eth_signTypedData_v4` (meta-mask)

### DIFF
--- a/web3-wrapper/CHANGELOG.json
+++ b/web3-wrapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "7.3.0",
+        "changes": [
+            {
+                "note": "Add `Web3Wrapper.signTypedDataV4Async()` (metamask EIP712)",
+                "pr": 13
+            }
+        ]
+    },
+    {
         "timestamp": 1606873582,
         "version": "7.2.10",
         "changes": [

--- a/web3-wrapper/src/web3_wrapper.ts
+++ b/web3-wrapper/src/web3_wrapper.ts
@@ -349,6 +349,21 @@ export class Web3Wrapper {
         return signData;
     }
     /**
+     * Sign an EIP712 typed data message with a specific address's private key (MetaMask's `eth_signTypedData_v4`)
+     * @param address Address of signer
+     * @param typedData Typed data message to sign
+     * @returns Signature string (as RSV)
+     */
+    public async signTypedDataV4Async(address: string, typedData: any): Promise<string> {
+        assert.isETHAddressHex('address', address);
+        assert.doesConformToSchema('typedData', typedData, schemas.eip712TypedDataSchema);
+        const signData = await this.sendRawPayloadAsync<string>({
+            method: 'eth_signTypedData_v4',
+            params: [address, JSON.stringify(typedData)],
+        });
+        return signData;
+    }
+    /**
      * Fetches the latest block number
      * @returns Block number
      */


### PR DESCRIPTION
## Description

Our old `Web3Wrapper.signTypedDataAsync()` function called `eth_signTypedData`, which doesn't even work MM's current implementation of that RPC method. Maybe it works with some other provider's implementation so I'm leaving it alone and instead creating a `signTypedDataV4Async()`, which correctly calls `eth_signTypedData_v4`, which is MM's latest version of th EIP712 signing scheme.

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
