### PR TITLE
more robust eth_signTypedData support

### DIFF
--- a/subproviders/CHANGELOG.json
+++ b/subproviders/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.4.0",
+        "changes": [
+            {
+                "note": "Support `eth_signTypedData_v4` in `MetamaskSubprovider` and use the method name passed in",
+                "pr": 21
+            }
+        ]
+    },
+    {
         "timestamp": 1610044030,
         "version": "6.3.2",
         "changes": [

--- a/web3-wrapper/CHANGELOG.json
+++ b/web3-wrapper/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "7.4.0",
+        "changes": [
+            {
+                "note": "Remove `Web3Wrapper.signTypedDataV4Async()` and add backoff support for multiple versions of `eth_signTypedData` to `Web3Wrapper.signTypedDataAsync()`.",
+                "pr": 21
+            }
+        ]
+    },
+    {
         "timestamp": 1610044030,
         "version": "7.3.2",
         "changes": [


### PR DESCRIPTION
Depending on how you instantiate your providers (using provider engine or just a standardized provider), you can get inconsistent behavior when trying to perform an `eth_signTypedData` RPC call using MetaMask (+ probably other wallets). This attempts to make the behavior more consistent and more likely to succeed in different scenarios.
 
- Add support for new/multiple/explicit versions `eth_signTypedData_vX` to `MetaMaskSubprovider`.
- Remove `Web3Wrapper.signedTypeDataV4Async()`
- Automatically backoff to decreasing versions of `eth_signTypedData_vX` in `Web3Wrapper.signedTypeDataAsync()`.

This will break the `protocol-utils` package until it is updated to use `Web3Wrapper.signedTypeDataAsync()` (previously used `Web3Wrapper.signedTypeDataAsync()`).

## Description

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
