### PR TITLE
Fix: update ethereumjs-vm StateManager type

### DIFF
--- a/base-contract/CHANGELOG.json
+++ b/base-contract/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.2.19",
+        "changes": [
+            {
+                "note": "Remove reference to deprecated ethereumjs-vm/PStateManager",
+                "pr": 23
+            }
+        ]
+    },
+    {
         "timestamp": 1611645607,
         "version": "6.2.18",
         "changes": [

--- a/base-contract/package.json
+++ b/base-contract/package.json
@@ -60,7 +60,8 @@
         "uuid": "^3.3.2"
     },
     "resolutions": {
-        "merkle-patricia-tree": "^2.3.2"
+        "merkle-patricia-tree": "^2.3.2",
+        "ethereumjs-vm": "^4.2.0"
     },
     "publishConfig": {
         "access": "public"

--- a/typescript-typings/CHANGELOG.json
+++ b/typescript-typings/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "5.1.7",
+        "changes": [
+            {
+                "note": "Update definition for ethereumjs-vm/StateManager",
+                "pr": 23
+            }
+        ]
+    },
+    {
         "timestamp": 1606873582,
         "version": "5.1.6",
         "changes": [


### PR DESCRIPTION
## Description

In @0x/base-contract we were referencing a class `PStateManager` that has since been [removed](https://github.com/ethereumjs/ethereumjs-monorepo/pull/719) from the ethereumjs library. 

This was causing downstream errors wherever we use @0x/base-contract. Example:
```
Error: Cannot find module 'ethereumjs-vm/dist/state/promisified'
Require stack:
- /Users/xianny/src/protocol/packages/asset-swapper/node_modules/@0x/base-contract/lib/src/index.js
- /Users/xianny/src/protocol/packages/asset-swapper/node_modules/@0x/contract-wrappers/lib/src/index.js
- /Users/xianny/src/protocol/packages/asset-swapper/lib/src/utils/swap_quote_consumer_utils.js
- /Users/xianny/src/protocol/packages/asset-swapper/lib/src/quote_consumers/swap_quote_consumer.js
- /Users/xianny/src/protocol/packages/asset-swapper/lib/src/index.js
- /Users/xianny/src/0x-api/lib/src/app.js
- /Users/xianny/src/0x-api/lib/src/runners/http_service_runner.js
```

This PR updates @0x/base-contract and @0x/typescript-typings to be in line with the changes in https://github.com/ethereumjs/ethereumjs-monorepo/pull/719

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
