### PR TITLE
Fix a bug in config file lookup

### DIFF
--- a/sol-compiler/src/compiler.ts
+++ b/sol-compiler/src/compiler.ts
@@ -104,7 +104,7 @@ export class Compiler {
         overrides: Partial<CompilerOptions> = {},
         file: string = 'compiler.json',
     ): Promise<CompilerOptions> {
-        const fileConfig: CompilerOptions = (await promisify(fs.stat)(file)).isFile
+        const fileConfig: CompilerOptions = (await promisify(fs.stat)(file)).isFile()
             ? JSON.parse((await promisify(fs.readFile)(file, 'utf8')).toString())
             : {};
         assert.doesConformToSchema('compiler.json', fileConfig, compilerOptionsSchema);


### PR DESCRIPTION
sol-compiler didn't work without the compiler.json file present because we forgot to call the function and the function itself is always true.

## Description

<!--- Describe your changes in detail -->

## Testing instructions

Run sol-compiler without the config file before - it crashes.
Run it now - default options.

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed. (Would be nice to add a test for this regression but I'm too lazy)
-   [x] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
