### PR TITLE
Use ajv instead of jsonschema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     build:
         resource_class: medium+
         docker:
-            - image: nikolaik/python-nodejs:python3.7-nodejs10
+            - image: nikolaik/python-nodejs:python3.7-nodejs12
         working_directory: ~/repo
         steps:
             - checkout
@@ -27,7 +27,7 @@ jobs:
     test-publish:
         resource_class: medium+
         docker:
-            - image: nikolaik/python-nodejs:python3.7-nodejs10
+            - image: nikolaik/python-nodejs:python3.7-nodejs12
             - image: 0xorg/verdaccio
         working_directory: ~/repo
         steps:
@@ -41,7 +41,7 @@ jobs:
                   path: ~/.npm/_logs
     test-doc-generation:
         docker:
-            - image: nikolaik/python-nodejs:python3.7-nodejs10
+            - image: nikolaik/python-nodejs:python3.7-nodejs12
         working_directory: ~/repo
         steps:
             - restore_cache:
@@ -52,7 +52,7 @@ jobs:
                   no_output_timeout: 1200
     test-rest:
         docker:
-            - image: nikolaik/python-nodejs:python3.7-nodejs10
+            - image: nikolaik/python-nodejs:python3.7-nodejs12
         working_directory: ~/repo
         steps:
             - restore_cache:
@@ -113,7 +113,7 @@ jobs:
         resource_class: large
         working_directory: ~/repo
         docker:
-            - image: nikolaik/python-nodejs:python3.7-nodejs10
+            - image: nikolaik/python-nodejs:python3.7-nodejs12
         steps:
             - restore_cache:
                   keys:
@@ -124,7 +124,7 @@ jobs:
             - run: yarn diff_md_docs:ci
     submit-coverage:
         docker:
-            - image: nikolaik/python-nodejs:python3.7-nodejs10
+            - image: nikolaik/python-nodejs:python3.7-nodejs12
         working_directory: ~/repo
         steps:
             - restore_cache:

--- a/abi-gen/templates/TypeScript/contract.handlebars
+++ b/abi-gen/templates/TypeScript/contract.handlebars
@@ -80,11 +80,7 @@ export class {{contractName}}Contract extends BaseContract {
         logDecodeDependencies: { [contractName: string]: (ContractArtifact | SimpleContractArtifact) },
         {{> typed_params inputs=ctor.inputs}}
     ): Promise<{{contractName}}Contract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -108,11 +104,7 @@ export class {{contractName}}Contract extends BaseContract {
         logDecodeDependencies: { [contractName: string]: (ContractArtifact | SimpleContractArtifact) },
         {{> typed_params inputs=ctor.inputs}}
     ): Promise<{{contractName}}Contract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -146,11 +138,7 @@ export class {{contractName}}Contract extends BaseContract {
         {{> typed_params inputs=ctor.inputs}}
     ): Promise<{{contractName}}Contract> {
         assert.isHexString('bytecode', bytecode);
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [{{> params inputs=ctor.inputs}}] = BaseContract._formatABIDataItemList(

--- a/abi-gen/test-cli/output/typescript/abi_gen_dummy.ts
+++ b/abi-gen/test-cli/output/typescript/abi_gen_dummy.ts
@@ -71,11 +71,7 @@ export class AbiGenDummyContract extends BaseContract {
         txDefaults: Partial<TxData>,
         logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
     ): Promise<AbiGenDummyContract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -98,11 +94,7 @@ export class AbiGenDummyContract extends BaseContract {
         txDefaults: Partial<TxData>,
         logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
     ): Promise<AbiGenDummyContract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -132,11 +124,7 @@ export class AbiGenDummyContract extends BaseContract {
         logDecodeDependencies: { [contractName: string]: ContractAbi },
     ): Promise<AbiGenDummyContract> {
         assert.isHexString('bytecode', bytecode);
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(constructorAbi.inputs, [], BaseContract._bigNumberToString);

--- a/abi-gen/test-cli/output/typescript/lib_dummy.ts
+++ b/abi-gen/test-cli/output/typescript/lib_dummy.ts
@@ -50,11 +50,7 @@ export class LibDummyContract extends BaseContract {
         txDefaults: Partial<TxData>,
         logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
     ): Promise<LibDummyContract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -77,11 +73,7 @@ export class LibDummyContract extends BaseContract {
         txDefaults: Partial<TxData>,
         logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
     ): Promise<LibDummyContract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -111,11 +103,7 @@ export class LibDummyContract extends BaseContract {
         logDecodeDependencies: { [contractName: string]: ContractAbi },
     ): Promise<LibDummyContract> {
         assert.isHexString('bytecode', bytecode);
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(constructorAbi.inputs, [], BaseContract._bigNumberToString);

--- a/abi-gen/test-cli/output/typescript/test_lib_dummy.ts
+++ b/abi-gen/test-cli/output/typescript/test_lib_dummy.ts
@@ -51,11 +51,7 @@ export class TestLibDummyContract extends BaseContract {
         txDefaults: Partial<TxData>,
         logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
     ): Promise<TestLibDummyContract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -78,11 +74,7 @@ export class TestLibDummyContract extends BaseContract {
         txDefaults: Partial<TxData>,
         logDecodeDependencies: { [contractName: string]: ContractArtifact | SimpleContractArtifact },
     ): Promise<TestLibDummyContract> {
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         if (artifact.compilerOutput === undefined) {
             throw new Error('Compiler output not found in the artifact file');
         }
@@ -112,11 +104,7 @@ export class TestLibDummyContract extends BaseContract {
         logDecodeDependencies: { [contractName: string]: ContractAbi },
     ): Promise<TestLibDummyContract> {
         assert.isHexString('bytecode', bytecode);
-        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txDefaults', txDefaults, schemas.txDataSchema);
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         const constructorAbi = BaseContract._lookupConstructorAbi(abi);
         [] = BaseContract._formatABIDataItemList(constructorAbi.inputs, [], BaseContract._bigNumberToString);

--- a/assert/src/index.ts
+++ b/assert/src/index.ts
@@ -88,9 +88,11 @@ export const assert = {
         }
         const validationResult = schemaValidator.validate(value, schema);
         const hasValidationErrors = validationResult.errors && validationResult.errors.length > 0;
-        const msg = hasValidationErrors ? `Expected ${variableName} to conform to schema ${(schema as any).id}
+        const msg = hasValidationErrors
+            ? `Expected ${variableName} to conform to schema ${(schema as any).id}
 Encountered: ${JSON.stringify(value, null, '\t')}
-Validation errors: ${validationResult.errors!.join(', ')}` : '';
+Validation errors: ${validationResult.errors!.join(', ')}`
+            : '';
         assert.assert(!hasValidationErrors, msg);
     },
     doesMatchRegex(variableName: string, value: string, regex: RegExp): void {

--- a/assert/src/index.ts
+++ b/assert/src/index.ts
@@ -1,10 +1,10 @@
-import { Schema, SchemaValidator } from '@0x/json-schemas';
+import { SchemaValidator } from '@0x/json-schemas';
 import { addressUtils, BigNumber, logUtils } from '@0x/utils';
 import * as _ from 'lodash';
 import * as validUrl from 'valid-url';
 
 const HEX_REGEX = /^0x[0-9A-F]*$/i;
-
+const schemaValidator = new SchemaValidator();
 export const assert = {
     isBigNumber(variableName: string, value: BigNumber): void {
         const isBigNumber = BigNumber.isBigNumber(value);
@@ -79,19 +79,18 @@ export const assert = {
         const isWeb3Provider = _.isFunction(value.send) || _.isFunction(value.sendAsync);
         assert.assert(isWeb3Provider, assert.typeAssertionMessage(variableName, 'Provider', value));
     },
-    doesConformToSchema(variableName: string, value: any, schema: Schema, subSchemas?: Schema[]): void {
+    doesConformToSchema(variableName: string, value: any, schema: object, subSchemas?: object[]): void {
         if (value === undefined) {
             throw new Error(`${variableName} can't be undefined`);
         }
-        const schemaValidator = new SchemaValidator();
         if (subSchemas !== undefined) {
-            _.map(subSchemas, schemaValidator.addSchema.bind(schemaValidator));
+            schemaValidator.addSchema(subSchemas);
         }
         const validationResult = schemaValidator.validate(value, schema);
-        const hasValidationErrors = validationResult.errors.length > 0;
-        const msg = `Expected ${variableName} to conform to schema ${schema.id}
+        const hasValidationErrors = validationResult.errors && validationResult.errors.length > 0;
+        const msg = hasValidationErrors ? `Expected ${variableName} to conform to schema ${(schema as any).id}
 Encountered: ${JSON.stringify(value, null, '\t')}
-Validation errors: ${validationResult.errors.join(', ')}`;
+Validation errors: ${validationResult.errors!.join(', ')}` : '';
         assert.assert(!hasValidationErrors, msg);
     },
     doesMatchRegex(variableName: string, value: string, regex: RegExp): void {

--- a/base-contract/src/index.ts
+++ b/base-contract/src/index.ts
@@ -205,11 +205,7 @@ export class BaseContract {
         return txDataWithDefaults as TxData;
     }
     protected static _assertCallParams(callData: Partial<CallData>, defaultBlock?: BlockParam): void {
-        assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('callData', callData, schemas.callDataSchema);
         if (defaultBlock !== undefined) {
             assert.isBlockParam('defaultBlock', defaultBlock);
         }
@@ -376,11 +372,7 @@ export class BaseContract {
         }
         const provider = providerUtils.standardizeOrThrow(supportedProvider);
         if (callAndTxnDefaults !== undefined) {
-            assert.doesConformToSchema('callAndTxnDefaults', callAndTxnDefaults, schemas.callDataSchema, [
-                schemas.addressSchema,
-                schemas.numberSchema,
-                schemas.jsNumber,
-            ]);
+            assert.doesConformToSchema('callAndTxnDefaults', callAndTxnDefaults, schemas.callDataSchema);
         }
         this.contractName = contractName;
         this._web3Wrapper = new Web3Wrapper(provider, callAndTxnDefaults);

--- a/json-schemas/CHANGELOG.json
+++ b/json-schemas/CHANGELOG.json
@@ -4,7 +4,7 @@
         "changes": [
             {
                 "note": "Use ajv instead of jsonschema to improve performance",
-                "pr": 
+                "pr": 28
             }
         ]
     },

--- a/json-schemas/CHANGELOG.json
+++ b/json-schemas/CHANGELOG.json
@@ -1,6 +1,6 @@
 [
     {
-        "version": "5.4.2",
+        "version": "6.0.0",
         "changes": [
             {
                 "note": "Use ajv instead of jsonschema to improve performance",

--- a/json-schemas/CHANGELOG.json
+++ b/json-schemas/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "5.4.2",
+        "changes": [
+            {
+                "note": "Use ajv instead of jsonschema to improve performance",
+                "pr": 
+            }
+        ]
+    },
+    {
         "timestamp": 1610044030,
         "version": "5.4.1",
         "changes": [

--- a/json-schemas/package.json
+++ b/json-schemas/package.json
@@ -45,7 +45,7 @@
     "dependencies": {
         "@0x/typescript-typings": "^5.1.6",
         "@types/node": "12.12.54",
-        "jsonschema": "^1.2.0",
+        "ajv": "^6.12.5",
         "lodash.values": "^4.3.0"
     },
     "devDependencies": {

--- a/json-schemas/schemas/eip712_domain_schema.json
+++ b/json-schemas/schemas/eip712_domain_schema.json
@@ -5,7 +5,7 @@
             "type": "string"
         },
         "version": {
-            "type": "version"
+            "type": "string"
         },
         "chainId": {
             "type": "number"

--- a/json-schemas/src/index.ts
+++ b/json-schemas/src/index.ts
@@ -1,3 +1,5 @@
 export { SchemaValidator } from './schema_validator';
 export { schemas } from './schemas';
 export { Ajv } from 'ajv';
+import * as AJV from 'ajv';
+module.exports.AJV = AJV;

--- a/json-schemas/src/index.ts
+++ b/json-schemas/src/index.ts
@@ -1,2 +1,3 @@
 export { SchemaValidator } from './schema_validator';
 export { schemas } from './schemas';
+export { Ajv } from 'ajv';

--- a/json-schemas/src/index.ts
+++ b/json-schemas/src/index.ts
@@ -1,4 +1,2 @@
-export { ValidatorResult, Schema } from 'jsonschema';
-
 export { SchemaValidator } from './schema_validator';
 export { schemas } from './schemas';

--- a/json-schemas/src/schema_validator.ts
+++ b/json-schemas/src/schema_validator.ts
@@ -1,5 +1,6 @@
-import * as AJV from 'ajv';
-import { Ajv as IAjv } from 'ajv';
+import * as AJV from 'ajv'; // namespace and constructor
+// tslint:disable:no-duplicate-imports
+import { Ajv } from 'ajv'; // interface
 import values = require('lodash.values');
 
 import { schemas } from './schemas';
@@ -7,7 +8,7 @@ import { schemas } from './schemas';
  * A validator wrapping (AJV) [https://github.com/ajv-validator/ajv]
  */
 export class SchemaValidator {
-    private readonly _validator: IAjv;
+    private readonly _validator: Ajv;
     /**
      * Instantiates a SchemaValidator instance
      */
@@ -35,7 +36,7 @@ export class SchemaValidator {
      * @param schema Schema to check against
      * @returns The results of the validation
      */
-    public validate(instance: any, schema: object): IAjv {
+    public validate(instance: any, schema: object): Ajv {
         this.isValid(instance, schema);
         return this._validator; // errors field is returned here. Will be overwritten on the next validation.
     }

--- a/json-schemas/src/schema_validator.ts
+++ b/json-schemas/src/schema_validator.ts
@@ -12,7 +12,7 @@ export class SchemaValidator {
      * Instantiates a SchemaValidator instance
      */
     constructor(newSchemas: object[] = []) {
-        this._validator = new Ajv({schemaId: 'auto'});
+        this._validator = new Ajv({ schemaId: 'auto' });
         this._validator.addSchema(values(schemas).filter(s => s !== undefined && s.id !== undefined));
         this._validator.addSchema(newSchemas.filter(s => s !== undefined));
     }

--- a/json-schemas/src/schema_validator.ts
+++ b/json-schemas/src/schema_validator.ts
@@ -1,18 +1,18 @@
-import * as Ajv from 'ajv';
+import * as AJV from 'ajv';
+import { Ajv as IAjv } from 'ajv';
 import values = require('lodash.values');
 
 import { schemas } from './schemas';
-
 /**
  * A validator wrapping (AJV) [https://github.com/ajv-validator/ajv]
  */
 export class SchemaValidator {
-    private readonly _validator: Ajv.Ajv;
+    private readonly _validator: IAjv;
     /**
      * Instantiates a SchemaValidator instance
      */
     constructor(newSchemas: object[] = []) {
-        this._validator = new Ajv({ schemaId: 'auto' });
+        this._validator = new AJV({ schemaId: 'auto' });
         this._validator.addSchema(values(schemas).filter(s => s !== undefined && s.id !== undefined));
         this._validator.addSchema(newSchemas.filter(s => s !== undefined));
     }
@@ -35,7 +35,7 @@ export class SchemaValidator {
      * @param schema Schema to check against
      * @returns The results of the validation
      */
-    public validate(instance: any, schema: object): Ajv.Ajv {
+    public validate(instance: any, schema: object): IAjv {
         this.isValid(instance, schema);
         return this._validator; // errors field is returned here. Will be overwritten on the next validation.
     }

--- a/json-schemas/test/schema_test.ts
+++ b/json-schemas/test/schema_test.ts
@@ -46,7 +46,7 @@ describe('Schema', () => {
     const validateAgainstSchema = (testCases: any[], schema: any, shouldFail = false) => {
         forEach(testCases, (testCase: any) => {
             const validationResult = validator.validate(testCase, schema);
-            const hasErrors = validationResult.errors.length !== 0;
+            const hasErrors = validationResult.errors && validationResult.errors.length !== 0;
             if (shouldFail) {
                 if (!hasErrors) {
                     throw new Error(

--- a/json-schemas/tsconfig.json
+++ b/json-schemas/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "lib",
         "rootDir": ".",
+        "isolatedModules": false,
         "resolveJsonModule": true
     },
     "include": ["./src/**/*", "./test/**/*"],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "~1.16.3",
         "source-map-support": "^0.5.6",
-        "typescript": "3.0.1",
+        "typescript": "4.2.2",
         "wsrun": "^2.2.0"
     },
     "resolutions": {

--- a/web3-wrapper/src/web3_wrapper.ts
+++ b/web3-wrapper/src/web3_wrapper.ts
@@ -551,11 +551,7 @@ export class Web3Wrapper {
      * @returns Estimated gas cost
      */
     public async estimateGasAsync(txData: Partial<TxData>): Promise<number> {
-        assert.doesConformToSchema('txData', txData, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txData', txData, schemas.txDataSchema);
         const txDataHex = marshaller.marshalTxData(txData);
         const gasHex = await this.sendRawPayloadAsync<string>({ method: 'eth_estimateGas', params: [txDataHex] });
         const gas = utils.convertHexToNumber(gasHex);
@@ -568,11 +564,7 @@ export class Web3Wrapper {
      * @returns The raw call result
      */
     public async callAsync(callData: CallData, defaultBlock?: BlockParam): Promise<string> {
-        assert.doesConformToSchema('callData', callData, schemas.callDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('callData', callData, schemas.callDataSchema);
         if (defaultBlock !== undefined) {
             Web3Wrapper._assertBlockParam(defaultBlock);
         }
@@ -591,11 +583,7 @@ export class Web3Wrapper {
      * @returns Transaction hash
      */
     public async sendTransactionAsync(txData: TxData): Promise<string> {
-        assert.doesConformToSchema('txData', txData, schemas.txDataSchema, [
-            schemas.addressSchema,
-            schemas.numberSchema,
-            schemas.jsNumber,
-        ]);
+        assert.doesConformToSchema('txData', txData, schemas.txDataSchema);
         const txDataHex = marshaller.marshalTxData(txData);
         const txHash = await this.sendRawPayloadAsync<string>({ method: 'eth_sendTransaction', params: [txDataHex] });
         return txHash;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.9.1:
+ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.5, ajv@^6.9.1:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -7996,11 +7996,6 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonschema@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.3.0.tgz#def86ca039b4f4254e76528d173462bc5da36162"
-  integrity sha512-qg48ckmeeQNPyPAUVIb4Qgmg/U2Kgg5SuEyMs8Z72cnxsw5Ra088U/Foi6sMp/cs7sZ+LNrmvX0Ww+ohE2By0g==
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -12671,6 +12666,11 @@ typescript@3.7.x:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+
+typescript@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description

Our current jsonschema validator is real slow.

Courtesy of @opaolini :
https://github.com/ebdrup/json-schema-benchmark

The fastest library `ajv` is 100x faster than `jsonschema`.

This PR changes the underlying library to `ajv` but preserves the `SchemaValidator` interface in @0x/json-schema.
I've also changed `assert.doesConformToSchema` to use cached schemas, since adding and compiling a new schema is the most performance-intensive part.

We should always use EITHER `assert.doesConformToSchema` OR the `SchemaValidator` interface. I guess it depends on whether you prefer OO or functional style programming. But don't use both. 

Usage example:
```
import { SchemaValidator } from '@0x/json-schemas';
import { schemas } from './schemas'; // custom schemas
const validator = new SchemaValidator(Object.values(schemas).filter(s => s !== undefined && s.id !== undefined);

....
const result = validator.validate(someObj, someSchema);
console.log(result.errors);
```

OR:
```
import { assert } from '@0x/assert';

...
assert.doesConformToSchema(someObj, someSchema, [unloadedSubSchemas]);
```

## Testing instructions

Since this touches a few packages I'd like to publish (patch version only) and test on staging. 

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
