### PR TITLE
export and `EncodingRules` from utils

### DIFF
--- a/abi-gen/CHANGELOG.json
+++ b/abi-gen/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "5.5.2",
+        "changes": [
+            {
+                "note": "Use `EncodingRules` instead of `AbiEncoder.EncodingRules` in templates",
+                "pr": 37
+            }
+        ]
+    },
+    {
         "timestamp": 1619466964,
         "version": "5.5.1",
         "changes": [

--- a/abi-gen/templates/TypeScript/contract.handlebars
+++ b/abi-gen/templates/TypeScript/contract.handlebars
@@ -29,7 +29,7 @@ import {
     TxAccessListWithGas,
     SupportedProvider,
 } from 'ethereum-types';
-import { AbiEncoder, BigNumber, classUtils, hexUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, EncodingRules, hexUtils, logUtils, providerUtils } from '@0x/utils';
 import { EventCallback, IndexedFilterValues, SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { assert } from '@0x/assert';
@@ -381,7 +381,7 @@ export class {{contractName}}Contract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = {{contractName}}Contract.deployedBytecode,
-        encodingRules?: AbiEncoder.EncodingRules,
+        encodingRules?: EncodingRules,
     ) {
         super('{{contractName}}', {{contractName}}Contract.ABI(), address, supportedProvider, txDefaults, logDecodeDependencies, deployedBytecode, encodingRules);
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);

--- a/abi-gen/test-cli/output/typescript/abi_gen_dummy.ts
+++ b/abi-gen/test-cli/output/typescript/abi_gen_dummy.ts
@@ -29,7 +29,7 @@ import {
     TxAccessListWithGas,
     SupportedProvider,
 } from 'ethereum-types';
-import { BigNumber, classUtils, hexUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, EncodingRules, hexUtils, logUtils, providerUtils } from '@0x/utils';
 import { EventCallback, IndexedFilterValues, SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { assert } from '@0x/assert';
@@ -2140,6 +2140,7 @@ export class AbiGenDummyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = AbiGenDummyContract.deployedBytecode,
+        encodingRules?: EncodingRules,
     ) {
         super(
             'AbiGenDummy',
@@ -2149,6 +2150,7 @@ export class AbiGenDummyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            encodingRules,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         this._subscriptionManager = new SubscriptionManager<AbiGenDummyEventArgs, AbiGenDummyEvents>(

--- a/abi-gen/test-cli/output/typescript/lib_dummy.ts
+++ b/abi-gen/test-cli/output/typescript/lib_dummy.ts
@@ -27,7 +27,7 @@ import {
     TxAccessListWithGas,
     SupportedProvider,
 } from 'ethereum-types';
-import { BigNumber, classUtils, hexUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, EncodingRules, hexUtils, logUtils, providerUtils } from '@0x/utils';
 import { EventCallback, IndexedFilterValues, SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { assert } from '@0x/assert';
@@ -222,6 +222,7 @@ export class LibDummyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = LibDummyContract.deployedBytecode,
+        encodingRules?: EncodingRules,
     ) {
         super(
             'LibDummy',
@@ -231,6 +232,7 @@ export class LibDummyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            encodingRules,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         LibDummyContract.ABI().forEach((item, index) => {

--- a/abi-gen/test-cli/output/typescript/test_lib_dummy.ts
+++ b/abi-gen/test-cli/output/typescript/test_lib_dummy.ts
@@ -27,7 +27,7 @@ import {
     TxAccessListWithGas,
     SupportedProvider,
 } from 'ethereum-types';
-import { BigNumber, classUtils, hexUtils, logUtils, providerUtils } from '@0x/utils';
+import { AbiEncoder, BigNumber, classUtils, EncodingRules, hexUtils, logUtils, providerUtils } from '@0x/utils';
 import { EventCallback, IndexedFilterValues, SimpleContractArtifact } from '@0x/types';
 import { Web3Wrapper } from '@0x/web3-wrapper';
 import { assert } from '@0x/assert';
@@ -315,6 +315,7 @@ export class TestLibDummyContract extends BaseContract {
         txDefaults?: Partial<TxData>,
         logDecodeDependencies?: { [contractName: string]: ContractAbi },
         deployedBytecode: string | undefined = TestLibDummyContract.deployedBytecode,
+        encodingRules?: EncodingRules,
     ) {
         super(
             'TestLibDummy',
@@ -324,6 +325,7 @@ export class TestLibDummyContract extends BaseContract {
             txDefaults,
             logDecodeDependencies,
             deployedBytecode,
+            encodingRules,
         );
         classUtils.bindAll(this, ['_abiEncoderByFunctionSignature', 'address', '_web3Wrapper']);
         TestLibDummyContract.ABI().forEach((item, index) => {

--- a/utils/CHANGELOG.json
+++ b/utils/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "6.4.2",
+        "changes": [
+            {
+                "note": "Export `EncodingRules` and `DecodingRules` at the root level",
+                "pr": 37
+            }
+        ]
+    },
+    {
         "version": "6.4.1",
         "changes": [
             {

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -15,6 +15,7 @@ export { fetchAsync } from './fetch_async';
 export { signTypedDataUtils } from './sign_typed_data_utils';
 export { hexUtils } from './hex_utils';
 export import AbiEncoder = require('./abi_encoder');
+export { EncodingRules, DecodingRules } from './abi_encoder';
 export * from './types';
 export { generatePseudoRandom256BitNumber } from './random';
 export {


### PR DESCRIPTION
## Description

This is needed because the `AbiEncoder.EncodingRules` type is inaccessible in the `protocol` repo because of the dumb way we export `AbiEncoder` (using `export import`).

<!--- Describe your changes in detail -->

## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
