### PR TITLE
Allow hexUtils.hash() to take Buffer type; isHex() accepts '0x'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ sol-compiler/solc_bin/
 */docs/README.md
 
 .DS_Store
+.idea

--- a/utils/CHANGELOG.json
+++ b/utils/CHANGELOG.json
@@ -6,8 +6,7 @@
                 "note": "Allow hexUtils.hash() to take Buffer type; isHex() accepts '0x' as valid hex",
                 "pr": 42
             }
-        ],
-        "timestamp": 1628911540
+        ]
     },
     {
         "timestamp": 1619585664,

--- a/utils/CHANGELOG.json
+++ b/utils/CHANGELOG.json
@@ -1,5 +1,15 @@
 [
     {
+        "version": "6.4.4",
+        "changes": [
+            {
+                "note": "Allow hexUtils.hash() to take Buffer type; isHex() accepts '0x' as valid hex",
+                "pr": 42
+            }
+        ],
+        "timestamp": 1628911540
+    },
+    {
         "timestamp": 1619585664,
         "version": "6.4.3",
         "changes": [

--- a/utils/src/hex_utils.ts
+++ b/utils/src/hex_utils.ts
@@ -76,7 +76,8 @@ function slice(n: Numberish, start: number, end?: number): string {
  * Get the keccak hash of some data.
  */
 function hash(n: Numberish | Buffer): string {
-    return ethUtil.bufferToHex(ethUtil.keccak256(ethUtil.toBuffer(hexUtils.toHex(n))));
+    const buf = Buffer.isBuffer(n) ? n : ethUtil.toBuffer(hexUtils.toHex(n));
+    return ethUtil.bufferToHex(ethUtil.keccak256(buf));
 }
 
 /**

--- a/utils/src/hex_utils.ts
+++ b/utils/src/hex_utils.ts
@@ -75,7 +75,7 @@ function slice(n: Numberish, start: number, end?: number): string {
 /**
  * Get the keccak hash of some data.
  */
-function hash(n: Numberish): string {
+function hash(n: Numberish | Buffer): string {
     return ethUtil.bufferToHex(ethUtil.keccak256(ethUtil.toBuffer(hexUtils.toHex(n))));
 }
 
@@ -94,7 +94,7 @@ function toHex(n: Numberish | Buffer, _size: number = WORD_LENGTH): string {
     if (Buffer.isBuffer(n)) {
         return `0x${n.toString('hex')}`;
     }
-    if (typeof n === 'string' && /^0x[0-9a-f]+$/i.test(n)) {
+    if (typeof n === 'string' && isHex(n)) {
         // Already a hex.
         return n;
     }
@@ -117,5 +117,5 @@ function toHex(n: Numberish | Buffer, _size: number = WORD_LENGTH): string {
  * Check if a string is a hex string.
  */
 function isHex(s: string): boolean {
-    return /^0x[0-9a-f]+$/i.test(s);
+    return /^0x[0-9a-f]*$/i.test(s);
 }


### PR DESCRIPTION
## Description

1. Allow `hexUtils.hash()` to take Buffer type
2. Update `hexUtils.isHex()`, makes it accepts '0x'

<!--- Describe your changes in detail -->

## Testing instructions
yarn build
<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

* Bug fix (non-breaking change which fixes an issue)

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [x] Add new entries to the relevant CHANGELOG.jsons.
