### PR TITLE
Fix detection for `provider.send(payload,cb)` to use replaceAll inste…

### DIFF
--- a/utils/src/provider_utils.ts
+++ b/utils/src/provider_utils.ts
@@ -74,7 +74,7 @@ export const providerUtils = {
         } else if ((supportedProvider as any).send !== undefined) {
             // HACK(fabio): Detect if the `send` method has the old interface `send(payload, cb)` such
             // as in versions < Web3.js@1.0.0-beta.37. If so, do a simple re-mapping
-            if (_.includes((supportedProvider as any).send.toString().replace(' ', ''), 'function(payload,callback)')) {
+            if (_.includes((supportedProvider as any).send.toString().replaceAll(' ', ''), 'function(payload,callback)')) {
                 provider.sendAsync = (supportedProvider as any).send.bind(supportedProvider);
                 return provider;
             } else {


### PR DESCRIPTION
…ad of replace

## Description

Using just replace leads to the following string: 

```
'function(payload, callback) {
    var _this = this;
    var request = this._prepareRequest();
    request.onreadystatechange = function () {
        if (request.readyState === 4 && request.timeout !== 1) {
            var result = request.responseText;
            var error = null;
            try {
                result = JSON.parse(result);
            }
            catch (e) {
                error = errors.InvalidResponse(request.responseText);
            }
            _this.connected = true;
            callback(error, result);
        }
    };
    request.ontimeout = function () {
        _this.connected = false;
        callback(errors.ConnectionTimeout(this.timeout));
    };
    try {
        request.send(JSON.stringify(payload));
    }
    catch (error) {
        this.connected = false;
        callback(errors.InvalidConnection(this.host));
    }
}'
```

which doesn't check correctly for `'function(payload,callback)'`
## Testing instructions

<!--- Please describe how reviewers can test your changes -->

## Types of changes

<!--- What types of changes does your code introduce? Uncomment all the bullets that apply: -->

<!-- * Bug fix (non-breaking change which fixes an issue) -->

<!-- * New feature (non-breaking change which adds functionality) -->

<!-- * Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist:

<!--- The following points should be used to indicate the progress of your PR.  Put an `x` in all the boxes that apply right now, and come back over time and check them off as you make progress.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Prefix PR title with `[WIP]` if necessary.
-   [ ] Add tests to cover changes as needed.
-   [ ] Update documentation as needed.
-   [ ] Add new entries to the relevant CHANGELOG.jsons.
