### PR TITLE
Fix typo

### DIFF
--- a/subproviders/docs/reference.mdx
+++ b/subproviders/docs/reference.mdx
@@ -434,7 +434,7 @@ ___
 
 *Defined in [subproviders/mnemonic_wallet.ts:89](https://github.com/0xProject/tools/blob/c64730cff/subproviders/src/subproviders/mnemonic_wallet.ts#L89)*
 
-Signs a transaction with the account specificed by the `from` field in txParams.
+Signs a transaction with the account specified by the `from` field in txParams.
 If you've added this Subprovider to your  app's provider, you can simply send
 an `eth_sendTransaction` JSON RPC request, and this method will be called auto-magically.
 If you are not using this via a ProviderEngine instance, you can call it directly.


### PR DESCRIPTION
## ✏️ Fix Typo in `reference.mdx`  

### 🛠️ Description  
This PR corrects a small typo in **subproviders/docs/reference.mdx**:  
- Fixed **"specificed" → "specified"** for proper spelling.  

### ✅ Checklist  
- [x] Typo corrected  
- [ ] No functional or structural changes to the documentation  
- [ ] Follows project contribution guidelines  

### 🔗 Related Issues  
N/A  

### 🔍 How to Review  
1. Check the corrected spelling in `reference.mdx`.  
2. Ensure no additional unintended changes are present.  

Just a small cleanup for clarity! 🚀 Let me know if anything needs tweaking.  
