### PR TITLE
Typo fix

### DIFF
--- a/web3-wrapper/docs/reference.mdx
+++ b/web3-wrapper/docs/reference.mdx
@@ -505,7 +505,7 @@ ___
 
 *Defined in [web3-wrapper/src/web3_wrapper.ts:245](https://github.com/0xProject/tools/blob/c64730cff/web3-wrapper/src/web3_wrapper.ts#L245)*
 
-Fetch the current max piority fee per gas. This is the suggested miner tip
+Fetch the current max priority fee per gas. This is the suggested miner tip
 to get mined in the current block.
 
 **Returns:** *Promise‹BigNumber›*


### PR DESCRIPTION
This PR corrects the typo "piority" to "priority" in the documentation for the max priority fee per gas function. The change improves the clarity of the documentation.